### PR TITLE
Keep all laser scan planes parallel to each other by changing the Y value, instead of the pitch of the planes

### DIFF
--- a/lua/mod_config.lua
+++ b/lua/mod_config.lua
@@ -29,7 +29,8 @@ mod_config =
     angle_max = math.pi,
     range_min = 0.1,
     range_max = 30,
-    ignore_terrain = true
+    ignore_terrain = true,
+    inter_layer_distance = 0.1
   }
 }
 

--- a/modROS.lua
+++ b/modROS.lua
@@ -294,7 +294,8 @@ function ModROS:publish_laser_scan_func()
         -- get the cooridante(world) of each laser scanner's origin
         -- "mod_config.laser_scan.inter_layer_distance" is added between the scanning planes, along +y direction from the lowest laser scan plane
         -- and all laser scan planes are parallel to each other
-        local orig_x, orig_y, orig_z = localToWorld(self.instance_veh.cameraNode, 0, mod_config.laser_scan.inter_layer_distance * i, 0)
+        local laser_dy = mod_config.laser_scan.inter_layer_distance * i
+        local orig_x, orig_y, orig_z = localToWorld(self.instance_veh.cameraNode, 0, laser_dy, 0)
         for j = 0, (mod_config.laser_scan.num_rays - 1) do
             local seg_theta = j * delta_theta
             -- i_laser_dx, 0 , i_laser_dz is a point to define the raycasting direction

--- a/modROS.lua
+++ b/modROS.lua
@@ -332,10 +332,8 @@ function ModROS:publish_laser_scan_func()
         -- serialise to JSON and write to pipe
         self.file_pipe:write(sensor_msgs_LaserScan.ros_msg_name .. "\n" .. scan_msg:to_json())
 
-        -- the angle of the current layer's scanning plane wrt origin of the laser
-        local scanning_plane_pitch = 0
-        -- convert to quaternion for ROS TF; scanning_plane_pitch is the angle rotated from the origin of the laser scanner along y axis.
-        local q = ros_quaternion.from_euler(0, scanning_plane_pitch, 0)
+        -- convert to quaternion for ROS TF
+        local q = ros_quaternion.from_euler(0, 0, 0)
 
 
         -- get the tf from base_link to all laser frames

--- a/modROS.lua
+++ b/modROS.lua
@@ -349,7 +349,7 @@ function ModROS:publish_laser_scan_func()
             -- note the order of the axes here (see earlier comment about FS chirality)
             base_to_laser_z,
             base_to_laser_x,
-            base_to_laser_y + laser_dy * i,
+            base_to_laser_y + laser_dy,
             -- we don't need to swap the order of q, since the calculation of q is based on the ROS chirality
             q[1],
             q[2],

--- a/modROS.lua
+++ b/modROS.lua
@@ -291,7 +291,7 @@ function ModROS:publish_laser_scan_func()
     local delta_theta = LS_FOV / (mod_config.laser_scan.num_rays - 1)
     for i = 0, mod_config.laser_scan.num_layers-1 do
         self.laser_scan_array = {}
-        -- get the cooridante(world) of each laser scanner's origin
+        -- get the (world) coordinate of each laser scanner's origin
         -- "laser_dy" is added between the scanning planes, along +y direction from the lowest laser scan plane
         -- and all laser scan planes are parallel to each other
         local laser_dy = mod_config.laser_scan.inter_layer_distance * i

--- a/modROS.lua
+++ b/modROS.lua
@@ -292,7 +292,7 @@ function ModROS:publish_laser_scan_func()
     for i = 0, mod_config.laser_scan.num_layers-1 do
         self.laser_scan_array = {}
         -- get the cooridante(world) of each laser scanner's origin
-        -- "mod_config.laser_scan.inter_layer_distance" is added between the scanning planes, along +y direction from the lowest laser scan plane
+        -- "laser_dy" is added between the scanning planes, along +y direction from the lowest laser scan plane
         -- and all laser scan planes are parallel to each other
         local laser_dy = mod_config.laser_scan.inter_layer_distance * i
         local orig_x, orig_y, orig_z = localToWorld(self.instance_veh.cameraNode, 0, laser_dy, 0)
@@ -349,7 +349,7 @@ function ModROS:publish_laser_scan_func()
             -- note the order of the axes here (see earlier comment about FS chirality)
             base_to_laser_z,
             base_to_laser_x,
-            base_to_laser_y + mod_config.laser_scan.inter_layer_distance * i,
+            base_to_laser_y + laser_dy * i,
             -- we don't need to swap the order of q, since the calculation of q is based on the ROS chirality
             q[1],
             q[2],


### PR DESCRIPTION
This is related to #10. 
Now the laser scanners are mounted at different origins, so the beams won't cross each other