### PR TITLE
make laser scanner orientation configurable

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2410,7 +2410,8 @@ stds.modROS = {
         "tf2_msgs_TFMessage",
         "vehicle_util",
         "ros_names",
-        "mod_config"
+        "mod_config",
+        "frames"
     }
 }
 

--- a/lua/frames.lua
+++ b/lua/frames.lua
@@ -1,0 +1,34 @@
+--[[
+Copyright (c) 2021, TU Delft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+author: Ting-Chia Chiang
+author: G.A. vd. Hoorn
+--]]
+
+frames = {}
+
+function frames.create_attached_node(parentNodeId, transformName, tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
+    -- create a node
+    local node = createTransformGroup(transformName)
+    -- link the node to parentNodeId
+    link(parentNodeId, node)
+    -- apply a transfrom to the new node
+    setTranslation(node, tran_x, tran_y, tran_z)
+    setRotation(node, rot_x, rot_y, rot_z)
+    return node
+end
+
+return frames
+

--- a/lua/mod_config.lua
+++ b/lua/mod_config.lua
@@ -30,7 +30,20 @@ mod_config =
     range_min = 0.1,
     range_max = 30,
     ignore_terrain = true,
-    inter_layer_distance = 0.1
+    inter_layer_distance = 0.1,
+    -- apply a transform to first laser scan frame
+    laser_transform = {
+      translation = {
+          x = 0.0,
+          y = 0.0,
+          z = 0.0
+      },
+      rotation = {
+          x = -math.pi/6,
+          y = 0.0,
+          z = 0.0
+      }
+    }
   }
 }
 

--- a/lua/mod_config.lua
+++ b/lua/mod_config.lua
@@ -39,7 +39,7 @@ mod_config =
           z = 0.0
       },
       rotation = {
-          x = -math.pi/6,
+          x = math.pi/6,
           y = 0.0,
           z = 0.0
       }

--- a/lua/mod_config.lua
+++ b/lua/mod_config.lua
@@ -39,7 +39,8 @@ mod_config =
           z = 0.0
       },
       rotation = {
-          x = math.pi/6,
+          -- positive rotation over X rotates laser scanner down (ie: math.pi/6)
+          x = 0.0,
           y = 0.0,
           z = 0.0
       }

--- a/modROS.lua
+++ b/modROS.lua
@@ -74,15 +74,6 @@ local function center_camera_func()
     camera.rotY = camera.origRotY
 end
 
-local function createAttachedNode(parentNodeId, transformName, tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
-    local node = createTransformGroup(transformName)
-    link(parentNodeId, node)
-    -- apply a transfrom to node
-    setTranslation(node, tran_x, tran_y, tran_z)
-    setRotation(node, rot_x, rot_y, rot_z)
-    return node
-end
-
 local ModROS = {}
 ModROS.modDirectory = g_currentModDirectory
 

--- a/modROS.lua
+++ b/modROS.lua
@@ -74,6 +74,15 @@ local function center_camera_func()
     camera.rotY = camera.origRotY
 end
 
+local function createAttachedNode(parentNodeId, transformName, tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
+    local node = createTransformGroup(transformName)
+    link(parentNodeId, node)
+    -- apply a transfrom to node
+    setTranslation(node, tran_x, tran_y, tran_z)
+    setRotation(node, rot_x, rot_y, rot_z)
+    return node
+end
+
 local ModROS = {}
 ModROS.modDirectory = g_currentModDirectory
 
@@ -286,14 +295,6 @@ function ModROS:publish_laser_scan_func()
     local cos = math.cos
     local sin = math.sin
     local LS_FOV = mod_config.laser_scan.angle_max - mod_config.laser_scan.angle_min
-    -- adding the first laser scan frame to raycastNode (x left, y up, z into the page)
-    local laser_scan_frame_1 = createTransformGroup("laser_scan_frame_1")
-    link(self.instance_veh.cameraNode, laser_scan_frame_1)
-    -- apply a transfrom to laser_scan_frame_1
-    local x, y, z = 0, 0, 0
-    local rot_x, rot_y, rot_z = -math.pi/6, 0, 0
-    setTranslation(laser_scan_frame_1, x, y, z)
-    setRotation(laser_scan_frame_1, rot_x, rot_y, rot_z)
 
     -- calculate nr of steps between rays
     local delta_theta = LS_FOV / (mod_config.laser_scan.num_rays - 1)

--- a/modROS.lua
+++ b/modROS.lua
@@ -304,14 +304,14 @@ function ModROS:publish_laser_scan_func()
         -- "laser_dy" is added between the scanning planes, along +y direction from the lowest laser scan plane
         -- and all laser scan planes are parallel to each other
         local laser_dy = mod_config.laser_scan.inter_layer_distance * i
-        local orig_x, orig_y, orig_z = localToWorld(laser_scan_frame_1, 0, laser_dy, 0)
+        local orig_x, orig_y, orig_z = localToWorld(self.laser_frame_1, 0, laser_dy, 0)
 
         for j = 0, (mod_config.laser_scan.num_rays - 1) do
             local seg_theta = j * delta_theta
             -- (i_laser_dx, 0 , i_laser_dz) is a local space direction to define the world space raycasting (scanning) direction
             local i_laser_dx =  -sin(seg_theta) * radius
             local i_laser_dz =  -cos(seg_theta) * radius
-            local dx, dy, dz = localDirectionToWorld(laser_scan_frame_1, i_laser_dx, 0 , i_laser_dz)
+            local dx, dy, dz = localDirectionToWorld(self.laser_frame_1, i_laser_dx, 0 , i_laser_dz)
             self:laser_data_gen(orig_x, orig_y, orig_z, dx, dy, dz)
         end
 
@@ -343,10 +343,12 @@ function ModROS:publish_laser_scan_func()
 
         -- convert to quaternion for ROS TF
         -- note the order of the axes here (see earlier comment about FS chirality)
-        local q = ros_quaternion.from_euler(rot_z, rot_x, rot_y)
+        -- the rotation from base_link to raycastnode is the same as rotation from raycastnode to virtaul laser_frame as there is no rotation between base_link to raycastnode
+        local q = ros_quaternion.from_euler(mod_config.laser_scan.laser_transform.rotation.z, mod_config.laser_scan.laser_transform.rotation.x, mod_config.laser_scan.laser_transform.rotation.y)
 
         -- get the tf from base_link to all laser frames
-        local base_to_laser_x, base_to_laser_y, base_to_laser_z = localToLocal(laser_scan_frame_1, g_currentMission.controlledVehicle.components[1].node, 0, laser_dy, 0)
+        -- laser_dy is the offset from laser_frame_i to laser_frame_i+1
+        local base_to_laser_x, base_to_laser_y, base_to_laser_z = localToLocal(self.laser_frame_1, g_currentMission.controlledVehicle.components[1].node, 0, laser_dy, 0)
 
         -- create single TransformStamped message
         local tf_base_link_laser_frame_i = geometry_msgs_TransformStamped:init()
@@ -534,6 +536,11 @@ function ModROS:rosPubMsg(flag)
         --     print(instance_veh.cameraNode)
         end
 
+        -- create self.laser_frame_1 attached to raycastNode (x left, y up, z into the page)
+        -- and apply a transform to the self.laser_frame_1
+        local tran_x, tran_y, tran_z = mod_config.laser_scan.laser_transform.translation.x,  mod_config.laser_scan.laser_transform.translation.y,  mod_config.laser_scan.laser_transform.translation.z
+        local rot_x, rot_y, rot_z = mod_config.laser_scan.laser_transform.rotation.x, mod_config.laser_scan.laser_transform.rotation.y, mod_config.laser_scan.laser_transform.rotation.z
+        self.laser_frame_1 = createAttachedNode(self.instance_veh.cameraNode, "self.laser_frame_1", tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
 
     elseif flag == nil or flag == "" or flag == "false" then
         self.doPubMsg = false

--- a/modROS.lua
+++ b/modROS.lua
@@ -66,6 +66,7 @@ source(Utils.getFilename("lua/ros_time.lua", g_currentModDirectory))
 source(Utils.getFilename("lua/vehicle_util.lua", g_currentModDirectory))
 source(Utils.getFilename("lua/ros_names.lua", g_currentModDirectory))
 source(Utils.getFilename("lua/mod_config.lua", g_currentModDirectory))
+source(Utils.getFilename("lua/frames.lua", g_currentModDirectory))
 
 local function center_camera_func()
     local camIdx = g_currentMission.controlledVehicle.spec_enterable.camIndex
@@ -531,7 +532,7 @@ function ModROS:rosPubMsg(flag)
         -- and apply a transform to the self.laser_frame_1
         local tran_x, tran_y, tran_z = mod_config.laser_scan.laser_transform.translation.x, mod_config.laser_scan.laser_transform.translation.y, mod_config.laser_scan.laser_transform.translation.z
         local rot_x, rot_y, rot_z = mod_config.laser_scan.laser_transform.rotation.x, mod_config.laser_scan.laser_transform.rotation.y, mod_config.laser_scan.laser_transform.rotation.z
-        self.laser_frame_1 = createAttachedNode(self.instance_veh.cameraNode, "self.laser_frame_1", tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
+        self.laser_frame_1 = frames.create_attached_node(self.instance_veh.cameraNode, "self.laser_frame_1", tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
 
     elseif flag == nil or flag == "" or flag == "false" then
         self.doPubMsg = false

--- a/modROS.lua
+++ b/modROS.lua
@@ -295,13 +295,13 @@ function ModROS:publish_laser_scan_func()
     local cos = math.cos
     local sin = math.sin
     local LS_FOV = mod_config.laser_scan.angle_max - mod_config.laser_scan.angle_min
-
     -- calculate nr of steps between rays
     local delta_theta = LS_FOV / (mod_config.laser_scan.num_rays - 1)
+
     for i = 0, mod_config.laser_scan.num_layers-1 do
         self.laser_scan_array = {}
-        -- get the (world) coordinate of each laser scanner's origin
-        -- "laser_dy" is added between the scanning planes, along +y direction from the lowest laser scan plane
+        -- get the (world) coordinate of each laser scanner's origin: (orig_x, orig_y, orig_z)
+        -- "laser_dy" is added between the scanning planes, along +y direction (locally) from the lowest laser scan plane
         -- and all laser scan planes are parallel to each other
         local laser_dy = mod_config.laser_scan.inter_layer_distance * i
         local orig_x, orig_y, orig_z = localToWorld(self.laser_frame_1, 0, laser_dy, 0)
@@ -343,10 +343,10 @@ function ModROS:publish_laser_scan_func()
 
         -- convert to quaternion for ROS TF
         -- note the order of the axes here (see earlier comment about FS chirality)
-        -- the rotation from base_link to raycastnode is the same as rotation from raycastnode to virtaul laser_frame as there is no rotation between base_link to raycastnode
+        -- the rotation from base_link to raycastnode is the same as rotation from raycastnode to virtaul laser_frame_i as there is no rotation between base_link to raycastnode
         local q = ros_quaternion.from_euler(mod_config.laser_scan.laser_transform.rotation.z, mod_config.laser_scan.laser_transform.rotation.x, mod_config.laser_scan.laser_transform.rotation.y)
 
-        -- get the tf from base_link to all laser frames
+        -- get the translation from base_link to laser_frame_i
         -- laser_dy is the offset from laser_frame_i to laser_frame_i+1
         local base_to_laser_x, base_to_laser_y, base_to_laser_z = localToLocal(self.laser_frame_1, g_currentMission.controlledVehicle.components[1].node, 0, laser_dy, 0)
 
@@ -538,7 +538,7 @@ function ModROS:rosPubMsg(flag)
 
         -- create self.laser_frame_1 attached to raycastNode (x left, y up, z into the page)
         -- and apply a transform to the self.laser_frame_1
-        local tran_x, tran_y, tran_z = mod_config.laser_scan.laser_transform.translation.x,  mod_config.laser_scan.laser_transform.translation.y,  mod_config.laser_scan.laser_transform.translation.z
+        local tran_x, tran_y, tran_z = mod_config.laser_scan.laser_transform.translation.x, mod_config.laser_scan.laser_transform.translation.y, mod_config.laser_scan.laser_transform.translation.z
         local rot_x, rot_y, rot_z = mod_config.laser_scan.laser_transform.rotation.x, mod_config.laser_scan.laser_transform.rotation.y, mod_config.laser_scan.laser_transform.rotation.z
         self.laser_frame_1 = createAttachedNode(self.instance_veh.cameraNode, "self.laser_frame_1", tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
 

--- a/modROS.lua
+++ b/modROS.lua
@@ -301,8 +301,8 @@ function ModROS:publish_laser_scan_func()
         for j = 0, (mod_config.laser_scan.num_rays - 1) do
             local seg_theta = j * delta_theta
             -- (i_laser_dx, 0 , i_laser_dz) is a local space direction to define the world space raycasting (scanning) direction
-            local i_laser_dx =  -sin(seg_theta) * radius
-            local i_laser_dz =  -cos(seg_theta) * radius
+            local i_laser_dx = -sin(seg_theta) * radius
+            local i_laser_dz = -cos(seg_theta) * radius
             local dx, dy, dz = localDirectionToWorld(self.laser_frame_1, i_laser_dx, 0 , i_laser_dz)
             self:laser_data_gen(orig_x, orig_y, orig_z, dx, dy, dz)
         end


### PR DESCRIPTION
This is to fix #17 

I've introduced an additional (first) laser frame/node which is attached to the camera raycastnode. The first laser frame can be oriented arbitrarily, and the remaining laser frames are all parallel to it.