### PR TITLE
Improve rosPubMsg user experience

### DIFF
--- a/modROS.lua
+++ b/modROS.lua
@@ -492,19 +492,21 @@ function ModROS:rosPubMsg(flag)
     if flag ~= nil and flag ~= "" and flag == "true" then
         self.path = ModROS.modDirectory .. "ROS_messages"
 
-        print("connecting to named pipe")
-        self.file_pipe = io.open(self.path, "w")
+        if not self.file_pipe then
+            print("connecting to named pipe")
+            self.file_pipe = io.open(self.path, "w")
 
-        -- check we could open the pipe
-        if self.file_pipe then
-            print("Opened '" .. self.path .. "'")
-        else
-            -- if not, print error to console and return
-            print("Could not open named pipe: unknown reason (FS Lua does not seem to provide it)")
-            print("Possible reasons:")
-            print(" - symbolic link was not created")
-            print(" - the 'all_in_one_publisher.py' script is not running")
-            return
+            -- check we could open the pipe
+            if self.file_pipe then
+                print("Opened '" .. self.path .. "'")
+            else
+                -- if not, print error to console and return
+                print("Could not open named pipe: unknown reason (FS Lua does not seem to provide it)")
+                print("Possible reasons:")
+                print(" - symbolic link was not created")
+                print(" - the 'all_in_one_publisher.py' script is not running")
+                return
+            end
         end
 
         -- raycastNode initialization

--- a/modROS.lua
+++ b/modROS.lua
@@ -555,6 +555,7 @@ function ModROS:rosPubMsg(flag)
 
         if self.file_pipe then
             self.file_pipe:close()
+            self.file_pipe = nil
             print("closing named pipe")
         end
     end

--- a/modROS.lua
+++ b/modROS.lua
@@ -556,7 +556,7 @@ function ModROS:rosPubMsg(flag)
         if self.file_pipe then
             self.file_pipe:close()
             self.file_pipe = nil
-            print("closing named pipe")
+            print("closed named pipe")
         end
     end
 end

--- a/modROS.lua
+++ b/modROS.lua
@@ -490,7 +490,6 @@ end
 addConsoleCommand("rosPubMsg", "write ros messages to named pipe", "rosPubMsg", ModROS)
 function ModROS:rosPubMsg(flag)
     if flag ~= nil and flag ~= "" and flag == "true" then
-        self.doPubMsg = true
         self.path = ModROS.modDirectory .. "ROS_messages"
 
         print("connecting to named pipe")
@@ -544,6 +543,9 @@ function ModROS:rosPubMsg(flag)
             local rot_x, rot_y, rot_z = mod_config.laser_scan.laser_transform.rotation.x, mod_config.laser_scan.laser_transform.rotation.y, mod_config.laser_scan.laser_transform.rotation.z
             self.laser_frame_1 = frames.create_attached_node(self.instance_veh.cameraNode, "self.laser_frame_1", tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
         end
+
+        -- initialisation was successful
+        self.doPubMsg = true
 
     elseif flag == nil or flag == "" or flag == "false" then
         self.doPubMsg = false


### PR DESCRIPTION
This changes the behaviour of the `rosPubMsg` console command slightly, such that it is a bit more robust against "incorrect" orders of invocation, players not being in a vehicle, pipes not being open, etc.

It's still possible to end up in a state where FS must be shut down, but it's a bit harder to get there now.

Especially the `open->close->open->...` cycle was broken before 73e8c18: calling `close()` on an FD apparently doesn't also `nil` it, so all the checks for `file_pipe == nil` failed without explicitly `nil`ling it.
