### PR TITLE
Make the collisionMask configurable

### DIFF
--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -86,8 +86,10 @@ function ModROS:loadMap()
 
     if mod_config.raycast.collision_mask then
         self.raycastMask = mod_config.raycast.collision_mask
+        print(("Using custom collision mask for laser scanner: 0x%08X"):format(self.raycastMask))
     else
         self.raycastMask = RC_MASK_UNKNOWN5 + RC_MASK_TRACTORS + RC_MASK_COMBINES + RC_MASK_TRAILERS + RC_MASK_DYN_OBJS
+        print(("Using default collision mask for laser scanner: 0x%08X"):format(self.raycastMask))
     end
 
     print("modROS (" .. ModROS.MOD_VERSION .. ") loaded")

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -88,7 +88,6 @@ function ModROS:loadMap()
         self.raycastMask = mod_config.raycast.collision_mask
     else
         self.raycastMask = RC_MASK_UNKNOWN5 + RC_MASK_TRACTORS + RC_MASK_COMBINES + RC_MASK_TRAILERS + RC_MASK_DYN_OBJS
-
     end
 
     print("modROS (" .. ModROS.MOD_VERSION .. ") loaded")

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -83,7 +83,13 @@ function ModROS:loadMap()
     local RC_MASK_COMBINES = math.pow(2,  7)
     local RC_MASK_TRAILERS = math.pow(2,  8)
     local RC_MASK_DYN_OBJS = math.pow(2, 12)
-    self.raycastMask = RC_MASK_UNKNOWN5 + RC_MASK_TRACTORS + RC_MASK_COMBINES + RC_MASK_TRAILERS + RC_MASK_DYN_OBJS
+
+    if mod_config.raycast.collision_mask then
+        self.raycastMask = mod_config.raycast.collision_mask
+    else
+        self.raycastMask = RC_MASK_UNKNOWN5 + RC_MASK_TRACTORS + RC_MASK_COMBINES + RC_MASK_TRAILERS + RC_MASK_DYN_OBJS
+
+    end
 
     print("modROS (" .. ModROS.MOD_VERSION .. ") loaded")
 end

--- a/src/mod_config.lua
+++ b/src/mod_config.lua
@@ -46,7 +46,8 @@ mod_config =
       }
     }
   },
-  -- the collision_mask for raycasting can be customized (ie: 0x12345678)
+  -- the collision_mask for raycasting can be customized. Both
+  -- decimal and hexadecimal notations are supported (ie: 9 and 0x9).
   raycast = {
     collision_mask = nil
   }

--- a/src/mod_config.lua
+++ b/src/mod_config.lua
@@ -45,6 +45,10 @@ mod_config =
           z = 0.0
       }
     }
+  },
+  -- the collision_mask for raycasting can be customized (ie: 0x12345678)
+  raycast = {
+    collision_mask = nil
   }
 }
 


### PR DESCRIPTION
This is related to #35.

I've made the collisionMask configurable for raycasting.

The default value is `nil` which means we would use our own hard-code value:


https://github.com/tud-cor/FS19_modROS/blob/5e8d48482b79c9608f7fdbe42f88f7e7ef0bc568/modROS.lua#L92-L98

But if users want to calculate own customized value, they can change `nil` to a value