### PR TITLE
Refactor: introduce Publisher class

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -25,6 +25,8 @@ stds.modROS = {
         "vehicle_util",
         "mod_config",
         "frames",
+        "Publisher",
+        "WriteOnlyFileConnection",
     }
 }
 

--- a/src/loader.lua
+++ b/src/loader.lua
@@ -43,6 +43,10 @@ source(Utils.getFilename("src/utils/vehicle_util.lua", directory))
 source(Utils.getFilename("src/utils/frames.lua", directory))
 source(Utils.getFilename("src/utils/ros.lua", directory))
 
+-- "ROS"
+source(Utils.getFilename("src/ros/WriteOnlyFileConnection.lua", directory))
+source(Utils.getFilename("src/ros/Publisher.lua", directory))
+
 -- main/default configuration
 -- TODO: add UI for all of this
 source(Utils.getFilename("src/mod_config.lua", directory))

--- a/src/ros/Publisher.lua
+++ b/src/ros/Publisher.lua
@@ -1,0 +1,72 @@
+--[[
+
+Copyright (c) 2021, TU Delft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+author: Ting-Chia Chiang, G.A. vd. Hoorn
+maintainer: Ting-Chia Chiang, G.A. vd. Hoorn
+
+--]]
+
+Publisher = {}
+
+local Publisher_mt = Class(Publisher)
+
+
+function Publisher.new(connection, topic_name, message_type)
+    local self = {}
+    setmetatable(self, Publisher_mt)
+
+    if message_type['ROS_MSG_NAME'] == nil then
+        -- TODO: implement proper logging
+        print(("message_type must have ROS_MSG_NAME key, can't find it in '%s'"):format(message_type))
+        return nil, "ctor error: invalid message_type"
+    end
+
+    -- NOTE: there is no locking, so concurrent access to the connection is not
+    -- guarded against. Serialisation of access is responsibility of owner of
+    -- the Publisher object
+    self._conx = connection
+
+    -- this is not really used in the current implementation. We rely on the "Python side"
+    -- to handle actual publishing for us, and they have hard-coded topic names (for now)
+    self._topic_name = topic_name
+
+    -- we need this to be able to tell the Python side what sort of message
+    -- we're serialising
+    self._message_type_name = message_type.ROS_MSG_NAME
+
+    return self
+end
+
+function Publisher:delete()
+    -- nothing to do. Connection object is not owned by this Publisher
+end
+
+function Publisher:publish(msg)
+    if msg.ROS_MSG_NAME ~= self._message_type_name then
+        return nil, ("Can't publish '%s' with publisher of type '%s'"):format(msg.ROS_MSG_NAME, self._message_type_name)
+    end
+    if not self._conx:is_connected() then
+        return nil, "Can't write to nil fd"
+    end
+
+    -- try writing the serialised message to the connection
+    local ret, err = self._conx:write(msg.ROS_MSG_NAME .. "\n" .. msg:to_json())
+    if not ret then
+        return nil, "Error publishing message: '" .. err .. "'"
+    end
+    return ret
+end

--- a/src/ros/WriteOnlyFileConnection.lua
+++ b/src/ros/WriteOnlyFileConnection.lua
@@ -1,0 +1,106 @@
+--[[
+
+Copyright (c) 2021, TU Delft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+author: Ting-Chia Chiang, G.A. vd. Hoorn
+maintainer: Ting-Chia Chiang, G.A. vd. Hoorn
+
+--]]
+
+WriteOnlyFileConnection = {}
+
+local WriteOnlyFileConnection_mt = Class(WriteOnlyFileConnection)
+
+
+function WriteOnlyFileConnection.new(uri)
+    local self = {}
+    setmetatable(self, WriteOnlyFileConnection_mt)
+
+    self._uri = uri
+    self._fd = nil
+
+    return self
+end
+
+function WriteOnlyFileConnection:delete()
+    self:close()
+end
+
+function WriteOnlyFileConnection:get_uri()
+    return self._uri
+end
+
+function WriteOnlyFileConnection:_open()
+    -- NOTE: this is not guarded in any way
+    -- TODO: allow specifying flags
+    self._fd = io.open(self._uri, "w")
+    if not self._fd then
+        return nil, "Could not open uri: unknown reason (FS Lua does not provide one)"
+    end
+    return true
+end
+
+function WriteOnlyFileConnection:_close()
+    -- NOTE: this is not guarded in any way
+    self._fd:close()
+    self._fd = nil
+    return true
+end
+
+function WriteOnlyFileConnection:connect()
+    -- only connect if we're not already connected
+    if self:is_connected() then
+        return nil, "Already connected"
+    end
+
+    local ret, err = self:_open()
+    if not ret then
+        return nil, "Could not connect: '" .. err .. "'"
+    end
+    return ret
+end
+
+function WriteOnlyFileConnection:disconnect()
+    -- only disconnect if we're actually connected
+    if not self:is_connected() then
+        return nil, "Not connected"
+    end
+
+    local ret, err = self:_close()
+    if not ret then
+        return nil, "Could not disconnect: '" .. err .. "'"
+    end
+    return ret
+end
+
+function WriteOnlyFileConnection:get_fd()
+    return self._fd
+end
+
+function WriteOnlyFileConnection:is_connected()
+    --TODO: find a better way to figure out whether a file is still open.
+    -- io.type(..) does not appear to be supported :(
+    return (self._fd ~= nil)
+end
+
+function WriteOnlyFileConnection:write(data)
+    if not self:is_connected() then
+        return nil, "Not connected"
+    end
+    -- does write() return anything?
+    self._fd:write(data)
+    return true
+end


### PR DESCRIPTION
As per subject.

This introduces a lightweight abstraction around writing serialised message tables to the file descriptor we use to communicate with the Python side.

Besides making the code in `modROS.lua` somewhat easier to read, this also prevents implementation details about *how* we currently publish from leaking everywhere.

This is also preparation for the introduction of sensor classes, which are responsible for publishing their own messages.

Tested in FS.

---

Edit: I've gone back and added a "connection" abstraction as well. Right now this is just a simple wrapper around the file descriptor, but if/when we have something else (a socket?) this would make it easy to switch to that. The connection also decouples initialisation of dependent objects (such as the publishers) from the state of the file descriptor itself, making for slightly nicer resource management.
