### PR TITLE
Improvements in per-vehicle sensors

### DIFF
--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -90,8 +90,14 @@ end
 function ModROS.installSpecializations(vehicleTypeManager, specializationManager, modDirectory, modName)
     specializationManager:addSpecialization("rosVehicle", "RosVehicle", Utils.getFilename("src/vehicles/RosVehicle.lua", modDirectory), nil) -- Nil is important here
 
-    for typeName, _ in pairs(vehicleTypeManager:getVehicleTypes()) do
-        vehicleTypeManager:addSpecialization(typeName, modName .. ".rosVehicle")
+    for typeName, typeEntry in pairs(vehicleTypeManager:getVehicleTypes()) do
+        -- only if the prerequisites of specialization are fulfilled, specializations <rosVehicle> will be installed
+        -- in RosVehicle.lua, spec <drivable> is set as one of prerequisites for now
+        -- hence, if there exists no this condition, an error will occur: Not all prerequisites of specialization modROS.rosVehicle are fulfilled
+
+        if SpecializationUtil.hasSpecialization(Drivable, typeEntry.specializations) then
+            vehicleTypeManager:addSpecialization(typeName, modName .. ".rosVehicle")
+        end
     end
 
 end

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -114,7 +114,7 @@ function ModROS:update(dt)
             self:publish_veh_odom_func()
             self:publish_laser_scan_func()
             self:publish_imu_func()
-            self._pub_tf:publish(self.tf_msg, "tf")
+            self._pub_tf:publish(self.tf_msg)
 
         end
     end
@@ -137,7 +137,7 @@ end
 function ModROS:publish_sim_time_func()
     local msg = rosgraph_msgs_Clock.new()
     msg.clock = ros.Time.now()
-    self._pub_clock:publish(msg, "clock")
+    self._pub_clock:publish(msg)
 end
 
 

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -80,12 +80,9 @@ function ModROS:loadMap()
     self.path = ModROS.MOD_DIR .. "ROS_messages"
     self._conx = WriteOnlyFileConnection.new(self.path)
 
-    -- initialise publishers
+    -- initialise no-namespace-specific publishers
     self._pub_tf = Publisher.new(self._conx, "tf", tf2_msgs_TFMessage)
     self._pub_clock = Publisher.new(self._conx, "clock", rosgraph_msgs_Clock)
-    self._pub_odom = Publisher.new(self._conx, "odom", nav_msgs_Odometry)
-    self._pub_scan = Publisher.new(self._conx, "scan", sensor_msgs_LaserScan)
-    self._pub_imu = Publisher.new(self._conx, "imu", sensor_msgs_Imu)
 
     print("modROS (" .. ModROS.MOD_VERSION .. ") loaded")
 end

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -172,14 +172,11 @@ end
 -- A.4. imu publisher
 -- a function to publish get the position and orientaion of unmanned or manned vehicle(s) get and write to the named pipe (symbolic link)
 function ModROS:publish_imu_func()
-    if mod_config.control_only_active_one then
-        local vehicle = g_currentMission.controlledVehicle
-        local ros_time = ros.Time.now()
-        vehicle:pubImu(ros_time, self._pub_imu)
-    else
-        for _, vehicle in pairs(g_currentMission.vehicles) do
-            local ros_time = ros.Time.now()
-            vehicle:pubImu(ros_time, self._pub_imu)
+
+    local ros_time = ros.Time.now()
+    for _, vehicle in pairs(g_currentMission.vehicles) do
+        if vehicle.spec_rosVehicle then
+            vehicle:pubImu(ros_time)
         end
     end
 end

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -111,7 +111,7 @@ function ModROS:update(dt)
             self:publish_veh_odom_func()
             self:publish_laser_scan_func()
             self:publish_imu_func()
-            self._pub_tf:publish(self.tf_msg)
+            self._pub_tf:publish(self.tf_msg, "tf")
 
         end
     end
@@ -134,7 +134,7 @@ end
 function ModROS:publish_sim_time_func()
     local msg = rosgraph_msgs_Clock.new()
     msg.clock = ros.Time.now()
-    self._pub_clock:publish(msg)
+    self._pub_clock:publish(msg, "clock")
 end
 
 

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -114,7 +114,7 @@ function ModROS:update(dt)
         -- avoid publishing data if one is not inside a vehicle
         if self._conx:is_connected() and g_currentMission.controlledVehicle ~= nil then
             self:publish_sim_time_func()
-            self:publish_veh_func()
+            self:publish_veh_odom_func()
             self:publish_laser_scan_func()
             -- self:publish_imu_func()
             self._pub_tf:publish(self.tf_msg)
@@ -153,7 +153,7 @@ end
 
 -- B.2. odom publisher
 -- a function to publish ground-truth Pose and Twist of all vehicles (including non-drivable) based on their in-game position and orientation
-function ModROS:publish_veh_func()
+function ModROS:publish_veh_odom_func()
     -- FS time is "frozen" within a single call to update(..), so this
     -- will assign the same stamp to all Odometry messages
     local ros_time = ros.Time.now()

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -155,13 +155,8 @@ function ModROS:publish_laser_scan_func()
     -- FS time is "frozen" within a single call to update(..), so this
     -- will assign the same stamp to all LaserScan messages
     local ros_time = ros.Time.now()
-    if mod_config.control_only_active_one then
-        local vehicle = g_currentMission.controlledVehicle
+    for _, vehicle in pairs(g_currentMission.vehicles) do
         vehicle:pubLaserScan(ros_time, self.tf_msg, self._pub_scan)
-    else
-        for _, vehicle in pairs(g_currentMission.vehicles) do
-            vehicle:pubLaserScan(ros_time, self.tf_msg, self._pub_scan)
-        end
     end
 end
 

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -145,6 +145,7 @@ function ModROS:publish_veh_odom_func()
     -- will assign the same stamp to all Odometry messages
     local ros_time = ros.Time.now()
     for _, vehicle in pairs(g_currentMission.vehicles) do
+        -- only if the vehicle is spec_rosVehicle, the pubOdom() can be called
         vehicle:pubOdom(ros_time, self.tf_msg, self._pub_odom)
     end
 end
@@ -156,6 +157,7 @@ function ModROS:publish_laser_scan_func()
     -- will assign the same stamp to all LaserScan messages
     local ros_time = ros.Time.now()
     for _, vehicle in pairs(g_currentMission.vehicles) do
+        -- only if the vehicle is spec_rosVehicle, the pubLaserScan() can be called
         vehicle:pubLaserScan(ros_time, self.tf_msg, self._pub_scan)
     end
 end

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -24,13 +24,7 @@ The first one is to publish data, the second one is to subscribe data and the la
 ------------------------------------------------
 ------------------------------------------------
 
-A. Shared bits of information/infrastructure with RosVehicle spec
-1. getPublisher - instantiate publishers for each spec instance, called from RosVehicle.lua
-
-------------------------------------------------
-------------------------------------------------
-
-B: Publishing data
+A: Publishing data
 1. sim time publisher - publish in-game simulated clock. This message stops being published when the game is paused/exited
 2. odom publisher - publish ground-truth Pose and Twist of vehicles based on their in-game position and orientation
 3. laser scan publisher - publish the laser scan data
@@ -40,14 +34,14 @@ B: Publishing data
 ------------------------------------------------
 ------------------------------------------------
 
-C. Subscribing data
+B. Subscribing data
 1. ros_cmd_teleop subscriber - give the vehicle control to ROS
 2. A command for taking over control of a vehicle in the game : "rosControlVehicle true/false"
 
 ------------------------------------------------
 ------------------------------------------------
 
-D. Force-centering the camera
+C. Force-centering the camera
 1. A command for force-centering the current camera: "forceCenteredCamera true/false"
 
 ------------------------------------------------
@@ -143,7 +137,7 @@ end
 -- end
 
 
--- B.1 sim_time publisher: publish the farmsim time
+-- A.1 sim_time publisher: publish the farmsim time
 function ModROS:publish_sim_time_func()
     local msg = rosgraph_msgs_Clock.new()
     msg.clock = ros.Time.now()
@@ -151,7 +145,7 @@ function ModROS:publish_sim_time_func()
 end
 
 
--- B.2. odom publisher
+-- A.2. odom publisher
 -- a function to publish ground-truth Pose and Twist of all vehicles (including non-drivable) based on their in-game position and orientation
 function ModROS:publish_veh_odom_func()
     -- FS time is "frozen" within a single call to update(..), so this
@@ -163,7 +157,7 @@ function ModROS:publish_veh_odom_func()
 end
 
 
--- B.3. laser scan publisher
+-- A.3. laser scan publisher
 function ModROS:publish_laser_scan_func()
     -- FS time is "frozen" within a single call to update(..), so this
     -- will assign the same stamp to all LaserScan messages
@@ -179,7 +173,7 @@ function ModROS:publish_laser_scan_func()
 end
 
 
--- B.4. imu publisher
+-- A.4. imu publisher
 -- a function to publish get the position and orientaion of unmanned or manned vehicle(s) get and write to the named pipe (symbolic link)
 function ModROS:publish_imu_func()
     if mod_config.control_only_active_one then
@@ -194,7 +188,7 @@ function ModROS:publish_imu_func()
     end
 end
 
--- B.5. Console command allows to toggle publishers on/off: "rosPubMsg true/false"
+-- A.5. Console command allows to toggle publishers on/off: "rosPubMsg true/false"
 -- messages publisher console command
 addConsoleCommand("rosPubMsg", "write ros messages to named pipe", "rosPubMsg", ModROS)
 function ModROS:rosPubMsg(flag)
@@ -231,7 +225,7 @@ function ModROS:rosPubMsg(flag)
 end
 
 
--- C.1. ros_cmd_teleop subscriber
+-- B.1. ros_cmd_teleop subscriber
 -- a function to input the ROS geometry_msgs/Twist into the game to take over control of all vehicles
 function ModROS:subscribe_ROScontrol_func(dt)
     for _, vehicle in pairs(g_currentMission.vehicles) do
@@ -270,7 +264,7 @@ end
 
 
 
--- C.2. A command for taking over control of a vehicle in the game : "rosControlVehicle true/false"
+-- B.2. A command for taking over control of a vehicle in the game : "rosControlVehicle true/false"
 
 -- TODO Allow control of vehicles other than the 'active one'. (the console name has already been changed, but the implementation hasn't yet)
 
@@ -287,7 +281,7 @@ function ModROS:rosControlVehicle(flag)
 end
 
 
--- D.1 A command for force-centering the current camera: "forceCenteredCamera true/false"
+-- C.1 A command for force-centering the current camera: "forceCenteredCamera true/false"
 -- centering the camera by setting the camera rotX, rotY to original angles
 addConsoleCommand("forceCenteredCamera", "force-center the current camera", "forceCenteredCamera", ModROS)
 function ModROS:forceCenteredCamera(flag)

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -149,7 +149,9 @@ function ModROS:publish_veh_odom_func()
     local ros_time = ros.Time.now()
     for _, vehicle in pairs(g_currentMission.vehicles) do
         -- only if the vehicle is spec_rosVehicle, the pubOdom() can be called
-        vehicle:pubOdom(ros_time, self.tf_msg, self._pub_odom)
+        if vehicle.spec_rosVehicle then
+            vehicle:pubOdom(ros_time, self.tf_msg)
+        end
     end
 end
 
@@ -161,7 +163,9 @@ function ModROS:publish_laser_scan_func()
     local ros_time = ros.Time.now()
     for _, vehicle in pairs(g_currentMission.vehicles) do
         -- only if the vehicle is spec_rosVehicle, the pubLaserScan() can be called
-        vehicle:pubLaserScan(ros_time, self.tf_msg, self._pub_scan)
+        if vehicle.spec_rosVehicle then
+            vehicle:pubLaserScan(ros_time, self.tf_msg)
+        end
     end
 end
 

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -91,10 +91,10 @@ function ModROS.installSpecializations(vehicleTypeManager, specializationManager
     specializationManager:addSpecialization("rosVehicle", "RosVehicle", Utils.getFilename("src/vehicles/RosVehicle.lua", modDirectory), nil) -- Nil is important here
 
     for typeName, typeEntry in pairs(vehicleTypeManager:getVehicleTypes()) do
-        -- only if the prerequisites of specialization are fulfilled, specializations <rosVehicle> will be installed
-        -- in RosVehicle.lua, spec <drivable> is set as one of prerequisites for now
-        -- hence, if there exists no this condition, an error will occur: Not all prerequisites of specialization modROS.rosVehicle are fulfilled
-
+        -- only add rosVehicle spec to vechile types thathave prerequiste drivable spec
+        -- if there is no this condition, the <rosVehicle> will be added to all vehicle types regardless of having drivable spec as prerequisite
+        -- there would be errors occur when running RosVehicle.prerequisitesPresent()
+        -- hence, only if the prerequisites of specialization are fulfilled, specializations <rosVehicle> will be installed
         if SpecializationUtil.hasSpecialization(Drivable, typeEntry.specializations) then
             vehicleTypeManager:addSpecialization(typeName, modName .. ".rosVehicle")
         end

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -130,13 +130,6 @@ function ModROS:update(dt)
 end
 
 
--- -- A.1 getPublisher - instantiate publishers for each spec instance, called from RosVehicle.lua
--- function ModROS:getPublisher(topic_name, topic_type)
---     local pub = Publisher.new(self._conx, topic_name, topic_type)
---     return pub
--- end
-
-
 -- A.1 sim_time publisher: publish the farmsim time
 function ModROS:publish_sim_time_func()
     local msg = rosgraph_msgs_Clock.new()

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -108,8 +108,7 @@ function ModROS:update(dt)
 
     if self.doPubMsg then
         -- avoid writing to the pipe if it isn't actually open
-        -- avoid publishing data if one is not inside a vehicle
-        if self._conx:is_connected() and g_currentMission.controlledVehicle ~= nil then
+        if self._conx:is_connected() then
             self:publish_sim_time_func()
             self:publish_veh_odom_func()
             self:publish_laser_scan_func()

--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -170,10 +170,10 @@ function ModROS:publish_laser_scan_func()
     local ros_time = ros.Time.now()
     if mod_config.control_only_active_one then
         local vehicle = g_currentMission.controlledVehicle
-        vehicle:fillLaserData(ros_time, self.tf_msg, self._pub_scan)
+        vehicle:pubLaserScan(ros_time, self.tf_msg, self._pub_scan)
     else
         for _, vehicle in pairs(g_currentMission.vehicles) do
-            vehicle:fillLaserData(ros_time, self.tf_msg, self._pub_scan)
+            vehicle:pubLaserScan(ros_time, self.tf_msg, self._pub_scan)
         end
     end
 end

--- a/src/mod_config.lua
+++ b/src/mod_config.lua
@@ -23,6 +23,7 @@ mod_config =
   vehicle = {
     case_ih_7210_pro = {
       laser_scan = {
+        is_mounted = true,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,
@@ -58,6 +59,7 @@ mod_config =
     },
     diesel_locomotive = {
       laser_scan = {
+        is_mounted = false,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,
@@ -92,6 +94,7 @@ mod_config =
     },
     fiat_1300dt = {
       laser_scan = {
+        is_mounted = true,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,
@@ -126,6 +129,7 @@ mod_config =
     },
     new_holland_tx_32 = {
       laser_scan = {
+        is_mounted = true,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,

--- a/src/mod_config.lua
+++ b/src/mod_config.lua
@@ -56,6 +56,9 @@ mod_config =
       -- TODO: describe what the "default mask" is exactly (which classes of objects are included / have their bit set to 1).
       raycast = {
         collision_mask = nil
+      },
+      imu = {
+        enabled = true
       }
     },
     diesel_locomotive = {
@@ -91,6 +94,9 @@ mod_config =
       -- decimal and hexadecimal notations are supported (ie: 9 and 0x9).
       raycast = {
         collision_mask = nil
+      },
+      imu = {
+        enabled = false
       }
     },
     fiat_1300dt = {
@@ -126,6 +132,9 @@ mod_config =
       -- decimal and hexadecimal notations are supported (ie: 9 and 0x9).
       raycast = {
         collision_mask = nil
+      },
+      imu = {
+        enabled = true
       }
     },
     new_holland_tx_32 = {
@@ -161,6 +170,9 @@ mod_config =
       -- decimal and hexadecimal notations are supported (ie: 9 and 0x9).
       raycast = {
         collision_mask = nil
+      },
+      imu = {
+        enabled = true
       }
     },
     default_vehicle = {
@@ -196,6 +208,9 @@ mod_config =
       -- decimal and hexadecimal notations are supported (ie: 9 and 0x9).
       raycast = {
         collision_mask = nil
+      },
+      imu = {
+        enabled = true
       }
     },
   }

--- a/src/mod_config.lua
+++ b/src/mod_config.lua
@@ -53,6 +53,7 @@ mod_config =
       -- the collision_mask for raycasting can be customized. Both
       -- decimal and hexadecimal notations are supported (ie: 9 and 0x9).
       -- if 'nil', the default mask will be used.
+      -- TODO: describe what the "default mask" is exactly (which classes of objects are included / have their bit set to 1).
       raycast = {
         collision_mask = nil
       }

--- a/src/mod_config.lua
+++ b/src/mod_config.lua
@@ -35,6 +35,8 @@ mod_config =
         laser_transform = {
           translation = {
               x = 0.0,
+              -- This lowers the origin of the scanner to be more in at an expected hight
+              -- since the original attachment point is on the bonnet and it's too high to see important obstacles
               y = -1.5,
               z = 0.0
           },
@@ -68,6 +70,8 @@ mod_config =
         laser_transform = {
           translation = {
               x = 0.0,
+              -- This lowers the origin of the scanner to be more in at an expected hight
+              -- since the original attachment point is on the bonnet and it's too high to see important obstacles
               y = -1.5,
               z = 0.0
           },
@@ -100,6 +104,8 @@ mod_config =
         laser_transform = {
           translation = {
               x = 0.0,
+              -- This lowers the origin of the scanner to be more in at an expected hight
+              -- since the original attachment point is on the bonnet and it's too high to see important obstacles
               y = -1.5,
               z = 0.0
           },
@@ -132,6 +138,8 @@ mod_config =
         laser_transform = {
           translation = {
               x = 0.0,
+              -- This lowers the origin of the scanner to be more in at an expected hight
+              -- since the original attachment point is on the bonnet and it's too high to see important obstacles
               y = -3,
               z = 0.0
           },

--- a/src/mod_config.lua
+++ b/src/mod_config.lua
@@ -23,7 +23,7 @@ mod_config =
   vehicle = {
     case_ih_7210_pro = {
       laser_scan = {
-        is_mounted = true,
+        enabled = true,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,
@@ -60,7 +60,7 @@ mod_config =
     },
     diesel_locomotive = {
       laser_scan = {
-        is_mounted = false,
+        enabled = false,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,
@@ -95,7 +95,7 @@ mod_config =
     },
     fiat_1300dt = {
       laser_scan = {
-        is_mounted = true,
+        enabled = true,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,
@@ -130,7 +130,7 @@ mod_config =
     },
     new_holland_tx_32 = {
       laser_scan = {
-        is_mounted = true,
+        enabled = true,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,
@@ -165,7 +165,7 @@ mod_config =
     },
     default_vehicle = {
       laser_scan = {
-        is_mounted = true,
+        enabled = true,
         num_rays = 64,
         num_layers = 2,
         angle_min = -math.pi,

--- a/src/mod_config.lua
+++ b/src/mod_config.lua
@@ -157,7 +157,42 @@ mod_config =
       raycast = {
         collision_mask = nil
       }
-    }
+    },
+    default_vehicle = {
+      laser_scan = {
+        is_mounted = true,
+        num_rays = 64,
+        num_layers = 2,
+        angle_min = -math.pi,
+        angle_max = math.pi,
+        range_min = 0.1,
+        range_max = 30,
+        ignore_terrain = true,
+        inter_layer_distance = 0.1,
+        -- apply a transform to first laser scan frame
+        laser_transform = {
+          translation = {
+              x = 0.0,
+              -- This lowers the origin of the scanner to be more in at an expected hight
+              -- since the original attachment point is on the bonnet and it's too high to see important obstacles
+              y = -1.5,
+              z = 0.0
+          },
+          rotation = {
+              -- positive rotation over X rotates laser scanner down (ie: math.pi/6)
+              x = 0.0,
+              y = 0.0,
+              z = 0.0
+          }
+        },
+        laser_attachments = "raycastNode(0)"
+      },
+      -- the collision_mask for raycasting can be customized. Both
+      -- decimal and hexadecimal notations are supported (ie: 9 and 0x9).
+      raycast = {
+        collision_mask = nil
+      }
+    },
   }
 }
 

--- a/src/ros/Publisher.lua
+++ b/src/ros/Publisher.lua
@@ -55,7 +55,7 @@ function Publisher:delete()
     -- nothing to do. Connection object is not owned by this Publisher
 end
 
-function Publisher:publish(msg, topic_name)
+function Publisher:publish(msg)
     if msg.ROS_MSG_NAME ~= self._message_type_name then
         return nil, ("Can't publish '%s' with publisher of type '%s'"):format(msg.ROS_MSG_NAME, self._message_type_name)
     end
@@ -67,7 +67,7 @@ function Publisher:publish(msg, topic_name)
     -- "topic_name" could be with or without namespace
     -- with e.g. "<ros_veh_name_with_id>/odom"
     -- wihtout e.g. "clock"
-    local ret, err = self._conx:write(topic_name .. "\n" .. msg.ROS_MSG_NAME .. "\n" .. msg:to_json())
+    local ret, err = self._conx:write(self._topic_name .. "\n" .. msg.ROS_MSG_NAME .. "\n" .. msg:to_json())
     if not ret then
         return nil, "Error publishing message: '" .. err .. "'"
     end

--- a/src/ros/Publisher.lua
+++ b/src/ros/Publisher.lua
@@ -55,7 +55,7 @@ function Publisher:delete()
     -- nothing to do. Connection object is not owned by this Publisher
 end
 
-function Publisher:publish(msg)
+function Publisher:publish(msg, topic_name)
     if msg.ROS_MSG_NAME ~= self._message_type_name then
         return nil, ("Can't publish '%s' with publisher of type '%s'"):format(msg.ROS_MSG_NAME, self._message_type_name)
     end
@@ -64,23 +64,10 @@ function Publisher:publish(msg)
     end
 
     -- try writing the serialised message to the connection
-    local ret, err = self._conx:write(msg.ROS_MSG_NAME .. "\n" .. msg:to_json())
-    if not ret then
-        return nil, "Error publishing message: '" .. err .. "'"
-    end
-    return ret
-end
-
-function Publisher:publish_with_ns(msg, vehicle_ns)
-    if msg.ROS_MSG_NAME ~= self._message_type_name then
-        return nil, ("Can't publish '%s' with publisher of type '%s'"):format(msg.ROS_MSG_NAME, self._message_type_name)
-    end
-    if not self._conx:is_connected() then
-        return nil, "Can't write to nil fd"
-    end
-
-    -- try writing the serialised message to the connection
-    local ret, err = self._conx:write(vehicle_ns .. "\n" .. msg.ROS_MSG_NAME .. "\n" .. msg:to_json())
+    -- "topic_name" could be with or without namespace
+    -- with e.g. "<ros_veh_name_with_id>/odom"
+    -- wihtout e.g. "clock"
+    local ret, err = self._conx:write(topic_name .. "\n" .. msg.ROS_MSG_NAME .. "\n" .. msg:to_json())
     if not ret then
         return nil, "Error publishing message: '" .. err .. "'"
     end

--- a/src/ros/Publisher.lua
+++ b/src/ros/Publisher.lua
@@ -42,6 +42,9 @@ function Publisher.new(connection, topic_name, message_type)
 
     -- this is not really used in the current implementation. We rely on the "Python side"
     -- to handle actual publishing for us, and they have hard-coded topic names (for now)
+    -- "topic_name" could be with or without namespace
+    -- with e.g. "<ros_veh_name_with_id>/odom"
+    -- wihtout e.g. "clock"
     self._topic_name = topic_name
 
     -- we need this to be able to tell the Python side what sort of message
@@ -64,9 +67,6 @@ function Publisher:publish(msg)
     end
 
     -- try writing the serialised message to the connection
-    -- "topic_name" could be with or without namespace
-    -- with e.g. "<ros_veh_name_with_id>/odom"
-    -- wihtout e.g. "clock"
     local ret, err = self._conx:write(self._topic_name .. "\n" .. msg.ROS_MSG_NAME .. "\n" .. msg:to_json())
     if not ret then
         return nil, "Error publishing message: '" .. err .. "'"

--- a/src/ros/Publisher.lua
+++ b/src/ros/Publisher.lua
@@ -40,8 +40,6 @@ function Publisher.new(connection, topic_name, message_type)
     -- the Publisher object
     self._conx = connection
 
-    -- this is not really used in the current implementation. We rely on the "Python side"
-    -- to handle actual publishing for us, and they have hard-coded topic names (for now)
     -- "topic_name" could be with or without namespace
     -- with e.g. "<ros_veh_name_with_id>/odom"
     -- wihtout e.g. "clock"

--- a/src/ros/Publisher.lua
+++ b/src/ros/Publisher.lua
@@ -70,3 +70,19 @@ function Publisher:publish(msg)
     end
     return ret
 end
+
+function Publisher:publish_with_ns(msg, vehicle_ns)
+    if msg.ROS_MSG_NAME ~= self._message_type_name then
+        return nil, ("Can't publish '%s' with publisher of type '%s'"):format(msg.ROS_MSG_NAME, self._message_type_name)
+    end
+    if not self._conx:is_connected() then
+        return nil, "Can't write to nil fd"
+    end
+
+    -- try writing the serialised message to the connection
+    local ret, err = self._conx:write(vehicle_ns .. "\n" .. msg.ROS_MSG_NAME .. "\n" .. msg:to_json())
+    if not ret then
+        return nil, "Error publishing message: '" .. err .. "'"
+    end
+    return ret
+end

--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -133,7 +133,7 @@ function LaserScanner:doScan(ros_time, tf_msg, pub_scan)
         --scan_msg.intensities = {}  -- we don't set this field (TODO: should we?)
 
         -- publish the message
-        pub_scan:publish_with_ns(scan_msg, spec.ros_veh_name)
+        pub_scan:publish_with_ns(scan_msg, spec.ros_veh_name_w_id)
 
         -- convert to quaternion for ROS TF
         -- note the order of the axes here (see earlier comment about FS chirality)

--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -142,7 +142,8 @@ function LaserScanner:doScan(ros_time, tf_msg, pub_scan)
         --scan_msg.intensities = {}  -- we don't set this field (TODO: should we?)
 
         -- publish the message
-        pub_scan:publish_with_ns(scan_msg, spec.ros_veh_name_w_id)
+        local topic_name = spec.ros_veh_name_with_id .. "/scan"
+        pub_scan:publish(scan_msg, topic_name)
 
         -- convert to quaternion for ROS TF
         -- note the order of the axes here (see earlier comment about FS chirality)

--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -64,15 +64,22 @@ function LaserScanner:getLaserData(laser_scan_array, x, y, z, dx_r, dy, dz_r)
     -- if laser_scan.ignore_terrain is set true then ignore the terrain when detected
 
     if self.vehicle_table.laser_scan.ignore_terrain then
-        if self.raycastDistance ~= self.INIT_RAY_DISTANCE and self.raycastTransformId ~= g_currentMission.terrainRootNode and self.raycastTransformId ~= self.vehicle.components[1].node and  self.raycastTransformId ~= self.vehicle.components[2].node  then
-            -- table.insert(self.laser_scan_array, self.raycastDistance/10)
-            table.insert(laser_scan_array, self.raycastDistance)
+        -- some vehicles do not have a 2nd component
+        if not self.vehicle.components[2] then
+            if self.raycastDistance ~= self.INIT_RAY_DISTANCE and self.raycastTransformId ~= g_currentMission.terrainRootNode and self.raycastTransformId ~= self.vehicle.components[1].node then
+                table.insert(laser_scan_array, self.raycastDistance)
+            else
+                table.insert(laser_scan_array, self.INIT_RAY_DISTANCE)
+            end
         else
-            table.insert(laser_scan_array, self.INIT_RAY_DISTANCE)
+            if self.raycastDistance ~= self.INIT_RAY_DISTANCE and self.raycastTransformId ~= g_currentMission.terrainRootNode and self.raycastTransformId ~= self.vehicle.components[1].node and  self.raycastTransformId ~= self.vehicle.components[2].node  then
+                table.insert(laser_scan_array, self.raycastDistance)
+            else
+                table.insert(laser_scan_array, self.INIT_RAY_DISTANCE)
+            end
         end
     else
         if self.raycastDistance ~= self.INIT_RAY_DISTANCE then
-            -- table.insert(self.laser_scan_array, self.raycastDistance/10)
             table.insert(laser_scan_array, self.raycastDistance)
         else
             table.insert(laser_scan_array, self.INIT_RAY_DISTANCE)

--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -132,7 +132,7 @@ function LaserScanner:doScan(ros_time, tf_msg, pub_scan)
         --scan_msg.intensities = {}  -- we don't set this field (TODO: should we?)
 
         -- publish the message
-        pub_scan:publish(scan_msg)
+        pub_scan:publish_with_ns(scan_msg, spec.ros_veh_name)
 
         -- convert to quaternion for ROS TF
         -- note the order of the axes here (see earlier comment about FS chirality)

--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -64,7 +64,9 @@ function LaserScanner:getLaserData(laser_scan_array, x, y, z, dx_r, dy, dz_r)
     -- if laser_scan.ignore_terrain is set true then ignore the terrain when detected
 
     if self.vehicle_table.laser_scan.ignore_terrain then
-        -- some vehicles do not have a 2nd component
+        -- this is a temporary method to filter out laser hits on the vehicle itself
+        -- in FS, there are many vehicles composed of 2 components: the first component is the main part and the second component is mostly the axis object(s).
+        -- however, some driveable vehicles do not have a 2nd component (e.g. diesel_locomotive). We need to exclude the condition of hitting 2nd component, if there exists no 2nd compoenent
         if not self.vehicle.components[2] then
             if self.raycastDistance ~= self.INIT_RAY_DISTANCE and self.raycastTransformId ~= g_currentMission.terrainRootNode and self.raycastTransformId ~= self.vehicle.components[1].node then
                 table.insert(laser_scan_array, self.raycastDistance)

--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -64,7 +64,8 @@ function LaserScanner:getLaserData(laser_scan_array, x, y, z, dx_r, dy, dz_r)
     -- if laser_scan.ignore_terrain is set true then ignore the terrain when detected
 
     if self.vehicle_table.laser_scan.ignore_terrain then
-        if self.raycastDistance ~= self.INIT_RAY_DISTANCE and self.raycastTransformId ~= g_currentMission.terrainRootNode and self.raycastTransformId ~= self.vehicle.components[1].node then
+        if self.raycastDistance ~= self.INIT_RAY_DISTANCE and self.raycastTransformId ~= g_currentMission.terrainRootNode and self.raycastTransformId ~= self.vehicle.components[1].node and  self.raycastTransformId ~= self.vehicle.components[2].node  then
+            -- table.insert(self.laser_scan_array, self.raycastDistance/10)
             table.insert(laser_scan_array, self.raycastDistance)
         else
             table.insert(laser_scan_array, self.INIT_RAY_DISTANCE)

--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -102,7 +102,7 @@ function LaserScanner:raycastCallback(transformId, _, _, _, distance, _, _, _)
 end
 
 
-function LaserScanner:doScan(ros_time, tf_msg, pub_scan)
+function LaserScanner:doScan(ros_time, tf_msg)
     local spec = self.vehicle.spec_rosVehicle
 
     for i = 0, spec.laser_scan_obj.vehicle_table.laser_scan.num_layers-1 do

--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -142,8 +142,7 @@ function LaserScanner:doScan(ros_time, tf_msg)
         --scan_msg.intensities = {}  -- we don't set this field (TODO: should we?)
 
         -- publish the message
-        local topic_name = spec.ros_veh_name_with_id .. "/scan"
-        pub_scan:publish(scan_msg, topic_name)
+        spec.pub_scan:publish(scan_msg)
 
         -- convert to quaternion for ROS TF
         -- note the order of the axes here (see earlier comment about FS chirality)

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -106,6 +106,13 @@ function RosVehicle:onLoad()
             print("nil camera")
 
         end
+
+        -- create laser_frame_1 attached to raycastNode (x left, y up, z into the page)
+        -- and apply a transform to the self.laser_frame_1
+        local tran_x, tran_y, tran_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.z
+        local rot_x, rot_y, rot_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.z
+        local laser_frame_1 = frames.create_attached_node(spec.instance_veh.cameraNode, self:getFullName(), tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
+        spec.LaserFrameNode = laser_frame_1
     end
 
     -- initialize publishers for Odometry, LaserScan and Imu messages for each rosVehicle
@@ -201,16 +208,9 @@ end
 function RosVehicle:pubLaserScan(ros_time, tf_msg)
 
     local spec = self.spec_rosVehicle
-
     -- only if the object of LaserScanner class was initialized in onload(), publish the LaserScan message
     -- otherwise return
     if spec.laser_scan_obj then
-        -- create laser_frame_1 attached to raycastNode (x left, y up, z into the page)
-        -- and apply a transform to the self.laser_frame_1
-        local tran_x, tran_y, tran_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.z
-        local rot_x, rot_y, rot_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.z
-        local laser_frame_1 = frames.create_attached_node(spec.instance_veh.cameraNode, self:getFullName(), tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
-        spec.LaserFrameNode = laser_frame_1
         spec.laser_scan_obj:doScan(ros_time, tf_msg)
     else
         return

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -78,7 +78,7 @@ function RosVehicle:pubOdom(ros_time, tf_msg, pub_odom)
 
 
     -- retrieve the vehicle node we're interested in:
-    -- A drivable vehicle is always composed of 2 components and the first component is always the main part.
+    -- A drivable vehicle is often composed of 2 components and the first component is the main part.
     -- The second component is mostly the axis object. Hence we take component1 as our vehicle
     -- The components can be checked/viewed in each vehicle's 3D model.
     local veh_node = self.components[1].node

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -68,8 +68,8 @@ function RosVehicle:onLoad()
     spec.base_link_frame = spec.ros_veh_name_with_id .. "/base_link"
     spec.component_1_node = self.components[1].node
     if not spec.component_1_node then
-        print(spec.ros_veh_name .. " does not have components[1].node")
-        print("Can not publish odom, scan and imu messages for " ..  spec.ros_veh_name .. "so return")
+        print(spec.ros_veh_name_with_id .. " does not have components[1].node")
+        print("Can not publish odom, scan and imu messages for " ..  spec.ros_veh_name_with_id)
     end
     -- Laser scanner initialization
 
@@ -80,7 +80,6 @@ function RosVehicle:onLoad()
     -- if the custom laser scanner is mounted (parameter enabled = true), initialize an object of LaserScanner class
     elseif mod_config.vehicle[spec.ros_veh_name].laser_scan.enabled then
         spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[spec.ros_veh_name])
-
     end
 
     --  only if the object of LaserScanner class was initialized (the laser scanner is enabled), initialize camera settings
@@ -101,7 +100,7 @@ function RosVehicle:onLoad()
             spec.instance_veh.vehicle.i3dMappings
         )
         if spec.instance_veh.cameraNode == nil then
-            print(spec.ros_veh_name .. " does not have cameraNode")
+            print(spec.ros_veh_name_with_id .. " does not have cameraNode")
             print("Can not publish laser scan messages for " .. spec.ros_veh_name)
         end
         -- create laser_frame_1 attached to raycastNode (x left, y up, z into the page)

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -57,6 +57,12 @@ function RosVehicle:onLoad()
     self.spec_rosVehicle = self["spec_" .. g_modROSModName .. ".rosVehicle"]
     local spec = self.spec_rosVehicle
     -- rosVehicle variables
+
+    -- there are two veh_name variables, one is with an id number and the other is without
+    -- because there could be situations where the same vehicle model is spawned more than once in the FS world
+    -- Hence, to create unique topic names for each vehicle, the name with id is necessary
+
+    -- variables without id are used as keys to retrieve config settings/tables
     -- .id is initialized by FS
     spec.ros_veh_name_with_id = ros.Names.sanatize(self:getFullName() .. "_" .. self.id)
     spec.ros_veh_name = ros.Names.sanatize(self:getFullName())

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -166,10 +166,10 @@ function RosVehicle:getLaserFrameNode()
         -- note: a laser scanner is always mounted in the default settings
         if not mod_config.vehicle[spec.ros_veh_name] then
             spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle["default_vehicle"])
-        -- if the custom laser scanner is mounted (parameter is_mounted = true), initialize an object of LaserScanner class
-        elseif mod_config.vehicle[spec.ros_veh_name].laser_scan.is_mounted then
+        -- if the custom laser scanner is mounted (parameter enabled = true), initialize an object of LaserScanner class
+        elseif mod_config.vehicle[spec.ros_veh_name].laser_scan.enabled then
             spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[spec.ros_veh_name])
-        -- if the custom laser scanner is not mounted (parameter is_mounted = false), do not initialize an object of LaserScanner class
+        -- if the custom laser scanner is not mounted (parameter enabled = false), do not initialize an object of LaserScanner class
         else
             return
         end

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -135,7 +135,7 @@ function RosVehicle:pubOdom(ros_time, tf_msg)
     -- if a vehicle somehow does not have self.components[1].node
     -- stop publishing odometry and return
     if not self.components[1].node then
-        print(spec.ros_veh_name .. " does not havve components[1].node")
+        print(spec.ros_veh_name .. " does not have components[1].node")
         print("Can not publish odom so return")
         return
     else

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -57,6 +57,12 @@ function RosVehicle:onLoad()
     -- .id is initialized by FS
     spec.ros_veh_name = ros.Names.sanatize(self:getFullName() .. "_" .. self.id)
     spec.base_link_frame = spec.ros_veh_name .. "/base_link"
+    spec.l_v_x_0 = 0
+    spec.l_v_y_0 = 0
+    spec.l_v_z_0 = 0
+    spec.sec = 0
+
+
 
 end
 

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -56,8 +56,9 @@ function RosVehicle:onLoad()
     local spec = self.spec_rosVehicle
     -- rosVehicle variables
     -- .id is initialized by FS
-    spec.ros_veh_name = ros.Names.sanatize(self:getFullName() .. "_" .. self.id)
-    spec.base_link_frame = spec.ros_veh_name .. "/base_link"
+    spec.ros_veh_name_w_id = ros.Names.sanatize(self:getFullName() .. "_" .. self.id)
+    spec.ros_veh_name = ros.Names.sanatize(self:getFullName())
+    spec.base_link_frame = spec.ros_veh_name_w_id .. "/base_link"
     spec.l_v_x_0 = 0
     spec.l_v_y_0 = 0
     spec.l_v_z_0 = 0
@@ -132,7 +133,7 @@ function RosVehicle:pubOdom(ros_time, tf_msg, pub_odom)
     -- TODO get AngularVelocity wrt local vehicle frame
     -- since the farmsim "getAngularVelocity()" can't get body-local angular velocity, we don't set odom_msg.twist.twist.angular for now
     -- publish the message
-    pub_odom:publish_with_ns(odom_msg, spec.ros_veh_name)
+    pub_odom:publish_with_ns(odom_msg, spec.ros_veh_name_w_id)
 
     -- get tf from odom to vehicles
     local tf_odom_vehicle_link = geometry_msgs_TransformStamped.new()
@@ -253,7 +254,7 @@ function RosVehicle:pubImu(ros_time, pub_imu)
     imu_msg.linear_acceleration.z = acc_y
 
     -- publish the message
-    pub_imu:publish_with_ns(imu_msg, spec.ros_veh_name)
+    pub_imu:publish_with_ns(imu_msg, spec.ros_veh_name_w_id)
 
     -- end
     -- end

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -32,7 +32,6 @@ end
 
 function RosVehicle.registerFunctions(vehicleType)
     SpecializationUtil.registerFunction(vehicleType, "addTF", RosVehicle.addTF)
-    SpecializationUtil.registerFunction(vehicleType, "getLaserFrameNode", RosVehicle.getLaserFrameNode)
     SpecializationUtil.registerFunction(vehicleType, "pubImu", RosVehicle.pubImu)
     SpecializationUtil.registerFunction(vehicleType, "pubLaserScan", RosVehicle.pubLaserScan)
     SpecializationUtil.registerFunction(vehicleType, "pubOdom", RosVehicle.pubOdom)
@@ -194,25 +193,19 @@ end
 function RosVehicle:pubLaserScan(ros_time, tf_msg)
 
     local spec = self.spec_rosVehicle
-    -- make sure the vechile is drivable and has laser frame node
-    if self:getLaserFrameNode() then
-        spec.laser_scan_obj:doScan(ros_time, tf_msg)
-    end
-end
 
-
-function RosVehicle:getLaserFrameNode()
-    local spec = self.spec_rosVehicle
-
-    if self.spec_drivable then
+    -- only if the object of LaserScanner class was initialized in onload(), publish the LaserScan message
+    -- otherwise return
+    if spec.laser_scan_obj then
+        -- create laser_frame_1 attached to raycastNode (x left, y up, z into the page)
         -- and apply a transform to the self.laser_frame_1
         local tran_x, tran_y, tran_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.z
         local rot_x, rot_y, rot_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.z
         local laser_frame_1 = frames.create_attached_node(spec.instance_veh.cameraNode, self:getFullName(), tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
         spec.LaserFrameNode = laser_frame_1
-        return spec.LaserFrameNode
+        spec.laser_scan_obj:doScan(ros_time, tf_msg)
     else
-        return nil
+        return
     end
 end
 

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -136,8 +136,7 @@ function RosVehicle:pubOdom(ros_time, tf_msg)
     -- TODO get AngularVelocity wrt local vehicle frame
     -- since the farmsim "getAngularVelocity()" can't get body-local angular velocity, we don't set odom_msg.twist.twist.angular for now
     -- publish the message
-    local topic_name = spec.ros_veh_name_with_id .. "/odom"
-    pub_odom:publish(odom_msg, topic_name)
+    spec.pub_odom:publish(odom_msg)
 
     -- get tf from odom to vehicles
     local tf_odom_vehicle_link = geometry_msgs_TransformStamped.new()
@@ -262,7 +261,6 @@ function RosVehicle:pubImu(ros_time)
     imu_msg.linear_acceleration.z = acc_y
 
     -- publish the message
-    local topic_name = spec.ros_veh_name_with_id .. "/imu"
-    pub_imu:publish(imu_msg, topic_name)
+    spec.pub_imu:publish(imu_msg)
 
 end

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -163,13 +163,17 @@ function RosVehicle:getLaserFrameNode()
     local spec = self.spec_rosVehicle
 
     if self.spec_drivable then
-        local current_veh_name = ros.Names.sanatize(self:getFullName())
 
-        -- if there is no custom laser scanner for this vehicle, use the default settings
-        if not mod_config.vehicle[current_veh_name] then
+        -- if there is no custom laser scanner setting for this vehicle, use the default settings to initialize an object of LaserScanner class
+        -- note: a laser scanner is always mounted in the default settings
+        if not mod_config.vehicle[spec.ros_veh_name] then
             spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle["default_vehicle"])
+        -- if the custom laser scanner is mounted (parameter is_mounted = true), initialize an object of LaserScanner class
+        elseif mod_config.vehicle[spec.ros_veh_name].laser_scan.is_mounted then
+            spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[spec.ros_veh_name])
+        -- if the custom laser scanner is not mounted (parameter is_mounted = false), do not initialize an object of LaserScanner class
         else
-            spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[current_veh_name])
+            return
         end
         --  get the cameraRaycast node 2(on top of ) which is 0 index .raycastNode(0)
         --  get the cameraRaycast node 3 (in the rear) which is 1 index .raycastNode(1)

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -21,7 +21,9 @@ RosVehicle = {}
 
 
 function RosVehicle.prerequisitesPresent(specializations)
-    -- make <drivable> spec as a prerequisite for now so that we only control vehicles which are drivable
+    -- make <drivable> spec as a prerequisite for rosVehicle since we only control vehicles which are drivable
+    -- if a vehicle does not have drivable spec, an error will occur
+    -- Not all prerequisites of specialization modROS.rosVehicle are fulfilled
     return SpecializationUtil.hasSpecialization(Drivable, specializations)
 end
 

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -32,6 +32,7 @@ end
 function RosVehicle.registerFunctions(vehicleType)
     SpecializationUtil.registerFunction(vehicleType, "addTF", RosVehicle.addTF)
     SpecializationUtil.registerFunction(vehicleType, "getLaserFrameNode", RosVehicle.getLaserFrameNode)
+    SpecializationUtil.registerFunction(vehicleType, "pubImu", RosVehicle.pubImu)
     SpecializationUtil.registerFunction(vehicleType, "pubLaserScan", RosVehicle.pubLaserScan)
     SpecializationUtil.registerFunction(vehicleType, "pubOdom", RosVehicle.pubOdom)
 end
@@ -189,4 +190,65 @@ function RosVehicle:getLaserFrameNode()
     else
         return nil
     end
+end
+
+
+function RosVehicle:pubImu(ros_time, pub_imu)
+
+    local spec = self.spec_rosVehicle
+    -- retrieve the vehicle node we're interested in
+    local veh_node = self.components[1].node
+
+    -- retrieve global (ie: world) coordinates of this node
+    local q_x, q_y, q_z, q_w = getWorldQuaternion(veh_node)
+
+    -- get twist data and calculate acc info
+
+    -- check getVelocityAtWorldPos and getVelocityAtLocalPos
+    -- local linear vel: Get velocity at local position of transform object; "getLinearVelocity" is the the velocity wrt world frame
+    -- local l_v_z max is around 8(i guess the unit is m/s here) when reach 30km/hr(shown in speed indicator)
+    local l_v_x, l_v_y, l_v_z = getLocalLinearVelocity(veh_node)
+    -- we don't use getAngularVelocity(veh_node) here as the return value is wrt the world frame not local frame
+
+    -- TODO add condition to filter out the vehicle: train because it does not have velocity info
+    -- for now we'll just use 0.0 as a replacement value
+    if not l_v_x then l_v_x = 0.0 end
+    if not l_v_y then l_v_y = 0.0 end
+    if not l_v_z then l_v_z = 0.0 end
+
+    -- calculation of linear acceleration in x,y,z directions
+    local acc_x = (l_v_x - spec.l_v_x_0) / (g_currentMission.environment.dayTime / 1000 - spec.sec)
+    local acc_y = (l_v_y - spec.l_v_y_0) / (g_currentMission.environment.dayTime / 1000 - spec.sec)
+    local acc_z = (l_v_z - spec.l_v_z_0) / (g_currentMission.environment.dayTime / 1000 - spec.sec)
+    -- update the velocity and time
+    spec.l_v_x_0 = l_v_x
+    spec.l_v_y_0 = l_v_y
+    spec.l_v_z_0 = l_v_z
+    spec.sec = g_currentMission.environment.dayTime / 1000
+
+
+    -- create sensor_msgs/Imu instance
+    local imu_msg = sensor_msgs_Imu.new()
+    -- populate fields (not using sensor_msgs_Imu:set(..) here as this is much
+    -- more readable than a long list of anonymous args)
+    imu_msg.header.frame_id = "base_link"
+    imu_msg.header.stamp = ros_time
+    -- note the order of the axes here (see earlier comment about FS chirality)
+    imu_msg.orientation.x = q_z
+    imu_msg.orientation.y = q_x
+    imu_msg.orientation.z = q_y
+    imu_msg.orientation.w = q_w
+    -- TODO get AngularVelocity wrt local vehicle frame
+    -- since the farmsim `getAngularVelocity()` can't get body-local angular velocity, we don't set imu_msg.angular_velocity for now
+
+    -- note again the order of the axes
+    imu_msg.linear_acceleration.x = acc_z
+    imu_msg.linear_acceleration.y = acc_x
+    imu_msg.linear_acceleration.z = acc_y
+
+    -- publish the message
+    pub_imu:publish_with_ns(imu_msg, spec.ros_veh_name)
+
+    -- end
+    -- end
 end

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -55,7 +55,7 @@ function RosVehicle:onLoad()
     -- rosVehicle namespace
     self.spec_rosVehicle = self["spec_" .. g_modROSModName .. ".rosVehicle"]
     local spec = self.spec_rosVehicle
-    -- rosVehicle variables
+    -- General rosVehicle variables
 
     -- there are two veh_name variables, one is with an id number and the other is without
     -- because there could be situations where the same vehicle model is spawned more than once in the FS world
@@ -71,14 +71,7 @@ function RosVehicle:onLoad()
         print(spec.ros_veh_name .. " does not have components[1].node")
         print("Can not publish odom, scan and imu messages for " ..  spec.ros_veh_name .. "so return")
     end
-
-    -- initialize linear velocity and time(s) for Imu messages
-    spec.l_v_x_0 = 0
-    spec.l_v_y_0 = 0
-    spec.l_v_z_0 = 0
-    spec.sec = 0
-
-    -- laser scanner initialization
+    -- Laser scanner initialization
 
     -- if there is no custom laser scanner setting for this vehicle, use the default settings to initialize an object of LaserScanner class
     -- note: a laser scanner is always mounted in the default settings
@@ -118,6 +111,15 @@ function RosVehicle:onLoad()
         local rot_x, rot_y, rot_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.z
         local laser_frame_1 = frames.create_attached_node(spec.instance_veh.cameraNode, self:getFullName(), tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
         spec.LaserFrameNode = laser_frame_1
+
+        -- Imu initialization
+
+        -- initialize linear velocity and time(s) for Imu messages
+        spec.l_v_x_0 = 0
+        spec.l_v_y_0 = 0
+        spec.l_v_z_0 = 0
+        spec.sec = 0
+
     end
 
     -- initialize publishers for Odometry, LaserScan and Imu messages for each rosVehicle

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -63,6 +63,10 @@ function RosVehicle:onLoad()
     spec.l_v_z_0 = 0
     spec.sec = 0
 
+    -- store the individual vehicle config file in the specialization to avoid reloading in the loop
+    spec.instance_veh = VehicleCamera:new(self, RosVehicle)
+    spec.xml_path = spec.instance_veh.vehicle.configFileName
+    spec.xmlFile = loadXMLFile("vehicle", spec.xml_path)
 
 
 end
@@ -161,21 +165,18 @@ function RosVehicle:getLaserFrameNode()
         local current_veh_name = ros.Names.sanatize(self:getFullName())
         spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[current_veh_name])
 
-        local instance_veh = VehicleCamera:new(self, RosVehicle)
-        local xml_path = instance_veh.vehicle.configFileName
-        local xmlFile = loadXMLFile("vehicle", xml_path)
         --  get the cameraRaycast node 2(on top of ) which is 0 index .raycastNode(0)
         --  get the cameraRaycast node 3 (in the rear) which is 1 index .raycastNode(1)
         local cameraKey = string.format("vehicle.enterable.cameras.camera(%d).%s", 0, spec.laser_scan_obj.vehicle_table.laser_scan.laser_attachments)
-        XMLUtil.checkDeprecatedXMLElements(xmlFile, xml_path, cameraKey .. "#index", "#node") -- FS17 to FS19
-        local camIndexStr = getXMLString(xmlFile, cameraKey .. "#node")
-        instance_veh.cameraNode =
+        XMLUtil.checkDeprecatedXMLElements(spec.xmlFile, spec.xml_path, cameraKey .. "#index", "#node") -- FS17 to FS19
+        local camIndexStr = getXMLString(spec.xmlFile, cameraKey .. "#node")
+        spec.instance_veh.cameraNode =
             I3DUtil.indexToObject(
-            instance_veh.vehicle.components,
+            spec.instance_veh.vehicle.components,
             camIndexStr,
-            instance_veh.vehicle.i3dMappings
+            spec.instance_veh.vehicle.i3dMappings
         )
-        if instance_veh.cameraNode == nil then
+        if spec.instance_veh.cameraNode == nil then
             print("nil camera")
         -- else
         --     print(instance_veh.cameraNode)
@@ -184,7 +185,7 @@ function RosVehicle:getLaserFrameNode()
         -- and apply a transform to the self.laser_frame_1
         local tran_x, tran_y, tran_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.z
         local rot_x, rot_y, rot_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.rotation.z
-        local laser_frame_1 = frames.create_attached_node(instance_veh.cameraNode, self:getFullName(), tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
+        local laser_frame_1 = frames.create_attached_node(spec.instance_veh.cameraNode, self:getFullName(), tran_x, tran_y, tran_z, rot_x, rot_y, rot_z)
         spec.LaserFrameNode = laser_frame_1
         return spec.LaserFrameNode
     else

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -56,9 +56,9 @@ function RosVehicle:onLoad()
     local spec = self.spec_rosVehicle
     -- rosVehicle variables
     -- .id is initialized by FS
-    spec.ros_veh_name_w_id = ros.Names.sanatize(self:getFullName() .. "_" .. self.id)
+    spec.ros_veh_name_with_id = ros.Names.sanatize(self:getFullName() .. "_" .. self.id)
     spec.ros_veh_name = ros.Names.sanatize(self:getFullName())
-    spec.base_link_frame = spec.ros_veh_name_w_id .. "/base_link"
+    spec.base_link_frame = spec.ros_veh_name_with_id .. "/base_link"
     spec.l_v_x_0 = 0
     spec.l_v_y_0 = 0
     spec.l_v_z_0 = 0

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -258,6 +258,4 @@ function RosVehicle:pubImu(ros_time, pub_imu)
     -- publish the message
     pub_imu:publish_with_ns(imu_msg, spec.ros_veh_name_w_id)
 
-    -- end
-    -- end
 end

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -122,7 +122,7 @@ function RosVehicle:pubOdom(ros_time, tf_msg, pub_odom)
     -- TODO get AngularVelocity wrt local vehicle frame
     -- since the farmsim "getAngularVelocity()" can't get body-local angular velocity, we don't set odom_msg.twist.twist.angular for now
     -- publish the message
-    pub_odom:publish(odom_msg)
+    pub_odom:publish_with_ns(odom_msg, spec.ros_veh_name)
 
     -- get tf from odom to vehicles
     local tf_odom_vehicle_link = geometry_msgs_TransformStamped.new()

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -67,6 +67,8 @@ function RosVehicle:onLoad()
     spec.ros_veh_name_with_id = ros.Names.sanatize(self:getFullName() .. "_" .. self.id)
     spec.ros_veh_name = ros.Names.sanatize(self:getFullName())
     spec.base_link_frame = spec.ros_veh_name_with_id .. "/base_link"
+
+    -- initialize linear velocity and time(s) for Imu messages
     spec.l_v_x_0 = 0
     spec.l_v_y_0 = 0
     spec.l_v_z_0 = 0
@@ -251,7 +253,7 @@ function RosVehicle:pubImu(ros_time)
     local acc_x = (l_v_x - spec.l_v_x_0) / (g_currentMission.environment.dayTime / 1000 - spec.sec)
     local acc_y = (l_v_y - spec.l_v_y_0) / (g_currentMission.environment.dayTime / 1000 - spec.sec)
     local acc_z = (l_v_z - spec.l_v_z_0) / (g_currentMission.environment.dayTime / 1000 - spec.sec)
-    -- update the velocity and time
+    -- update the linear velocity and time
     spec.l_v_x_0 = l_v_x
     spec.l_v_y_0 = l_v_y
     spec.l_v_z_0 = l_v_z

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -20,8 +20,8 @@ RosVehicle = {}
 -- RosVehicle.MOD_NAME = g_modROSModName
 
 
-function RosVehicle.prerequisitesPresent()
-    return true
+function RosVehicle.prerequisitesPresent(specializations)
+    return SpecializationUtil.hasSpecialization(Drivable, specializations)
 end
 
 

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -76,7 +76,7 @@ function RosVehicle:onLoad()
 end
 
 
-function RosVehicle:pubOdom(ros_time, tf_msg, pub_odom)
+function RosVehicle:pubOdom(ros_time, tf_msg)
 
     local spec = self.spec_rosVehicle
     local vehicle_base_link = spec.base_link_frame
@@ -153,12 +153,12 @@ function RosVehicle:addTF(tf_msg, TransformStamped)
 end
 
 
-function RosVehicle:pubLaserScan(ros_time, tf_msg, pub_scan)
+function RosVehicle:pubLaserScan(ros_time, tf_msg)
 
     local spec = self.spec_rosVehicle
     -- make sure the vechile is drivable and has laser frame node
     if self:getLaserFrameNode() then
-        spec.laser_scan_obj:doScan(ros_time, tf_msg, pub_scan)
+        spec.laser_scan_obj:doScan(ros_time, tf_msg)
     end
 end
 
@@ -208,7 +208,7 @@ function RosVehicle:getLaserFrameNode()
 end
 
 
-function RosVehicle:pubImu(ros_time, pub_imu)
+function RosVehicle:pubImu(ros_time)
 
     local spec = self.spec_rosVehicle
     -- retrieve the vehicle node we're interested in

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -131,7 +131,8 @@ function RosVehicle:pubOdom(ros_time, tf_msg, pub_odom)
     -- TODO get AngularVelocity wrt local vehicle frame
     -- since the farmsim "getAngularVelocity()" can't get body-local angular velocity, we don't set odom_msg.twist.twist.angular for now
     -- publish the message
-    pub_odom:publish_with_ns(odom_msg, spec.ros_veh_name_w_id)
+    local topic_name = spec.ros_veh_name_with_id .. "/odom"
+    pub_odom:publish(odom_msg, topic_name)
 
     -- get tf from odom to vehicles
     local tf_odom_vehicle_link = geometry_msgs_TransformStamped.new()
@@ -256,6 +257,7 @@ function RosVehicle:pubImu(ros_time, pub_imu)
     imu_msg.linear_acceleration.z = acc_y
 
     -- publish the message
-    pub_imu:publish_with_ns(imu_msg, spec.ros_veh_name_w_id)
+    local topic_name = spec.ros_veh_name_with_id .. "/imu"
+    pub_imu:publish(imu_msg, topic_name)
 
 end

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -211,6 +211,16 @@ end
 function RosVehicle:pubImu(ros_time)
 
     local spec = self.spec_rosVehicle
+    -- if there are no custom settings for this vehicle, use the default settings
+    if not mod_config.vehicle[spec.ros_veh_name] then
+        spec.imu = mod_config.vehicle["default_vehicle"].imu.enabled
+    else
+        spec.imu = mod_config.vehicle[spec.ros_veh_name].imu.enabled
+    end
+
+    -- if imu of this vehicle is disabled, return
+    if not spec.imu then return end
+
     -- retrieve the vehicle node we're interested in
     local veh_node = self.components[1].node
 

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -117,7 +117,12 @@ function RosVehicle:onLoad()
         spec.l_v_y_0 = 0
         spec.l_v_z_0 = 0
         spec.sec = 0
-
+    else
+        print("An object of LaserScanner class for " .. spec.ros_veh_name_with_id .. "was not initialized")
+        print("Can not publish laser scan messages for " .. spec.ros_veh_name_with_id)
+        print("Possible reason:")
+        print(" - there is no laser_scan.enabled configured in mod_config.lua")
+        print(" - laser_scan.enabled is set false")
     end
 
     -- initialize publishers for Odometry, LaserScan and Imu messages for each rosVehicle

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -74,6 +74,17 @@ function RosVehicle:onLoad()
     spec.l_v_z_0 = 0
     spec.sec = 0
 
+    -- laser scanner initialization
+
+    -- if there is no custom laser scanner setting for this vehicle, use the default settings to initialize an object of LaserScanner class
+    -- note: a laser scanner is always mounted in the default settings
+    if not mod_config.vehicle[spec.ros_veh_name] then
+        spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle["default_vehicle"])
+    -- if the custom laser scanner is mounted (parameter enabled = true), initialize an object of LaserScanner class
+    elseif mod_config.vehicle[spec.ros_veh_name].laser_scan.enabled then
+        spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[spec.ros_veh_name])
+
+    end
     -- store the individual vehicle config file in the specialization to avoid reloading in the loop
     spec.instance_veh = VehicleCamera:new(self, RosVehicle)
     spec.xml_path = spec.instance_veh.vehicle.configFileName
@@ -175,18 +186,6 @@ function RosVehicle:getLaserFrameNode()
     local spec = self.spec_rosVehicle
 
     if self.spec_drivable then
-
-        -- if there is no custom laser scanner setting for this vehicle, use the default settings to initialize an object of LaserScanner class
-        -- note: a laser scanner is always mounted in the default settings
-        if not mod_config.vehicle[spec.ros_veh_name] then
-            spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle["default_vehicle"])
-        -- if the custom laser scanner is mounted (parameter enabled = true), initialize an object of LaserScanner class
-        elseif mod_config.vehicle[spec.ros_veh_name].laser_scan.enabled then
-            spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[spec.ros_veh_name])
-        -- if the custom laser scanner is not mounted (parameter enabled = false), do not initialize an object of LaserScanner class
-        else
-            return
-        end
         --  get the cameraRaycast node 2(on top of ) which is 0 index .raycastNode(0)
         --  get the cameraRaycast node 3 (in the rear) which is 1 index .raycastNode(1)
         local cameraKey = string.format("vehicle.enterable.cameras.camera(%d).%s", 0, spec.laser_scan_obj.vehicle_table.laser_scan.laser_attachments)

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -163,8 +163,13 @@ function RosVehicle:getLaserFrameNode()
 
     if self.spec_drivable then
         local current_veh_name = ros.Names.sanatize(self:getFullName())
-        spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[current_veh_name])
 
+        -- if there is no custom laser scanner for this vehicle, use the default settings
+        if not mod_config.vehicle[current_veh_name] then
+            spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle["default_vehicle"])
+        else
+            spec.laser_scan_obj = LaserScanner.new(self, mod_config.vehicle[current_veh_name])
+        end
         --  get the cameraRaycast node 2(on top of ) which is 0 index .raycastNode(0)
         --  get the cameraRaycast node 3 (in the rear) which is 1 index .raycastNode(1)
         local cameraKey = string.format("vehicle.enterable.cameras.camera(%d).%s", 0, spec.laser_scan_obj.vehicle_table.laser_scan.laser_attachments)

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -101,10 +101,9 @@ function RosVehicle:onLoad()
             spec.instance_veh.vehicle.i3dMappings
         )
         if spec.instance_veh.cameraNode == nil then
-            print("nil camera")
-
+            print(spec.ros_veh_name .. " does not have cameraNode")
+            print("Can not publish laser scan messages for " .. spec.ros_veh_name)
         end
-
         -- create laser_frame_1 attached to raycastNode (x left, y up, z into the page)
         -- and apply a transform to the self.laser_frame_1
         local tran_x, tran_y, tran_z = spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.x, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.y, spec.laser_scan_obj.vehicle_table.laser_scan.laser_transform.translation.z
@@ -211,11 +210,14 @@ end
 
 
 function RosVehicle:pubLaserScan(ros_time, tf_msg)
-
     local spec = self.spec_rosVehicle
-    -- only if the object of LaserScanner class was initialized in onload(), publish the LaserScan message
+    -- only if
+    -- the object of LaserScanner class was initialized in onload()
+    -- and the component 1 node exists
+    -- and the cameraNode exists
+    -- then publish the LaserScan message
     -- otherwise return
-    if spec.laser_scan_obj then
+    if spec.laser_scan_obj and spec.component_1_node and spec.instance_veh.cameraNode then
         spec.laser_scan_obj:doScan(ros_time, tf_msg)
     else
         return

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -68,8 +68,6 @@ function RosVehicle:onLoad()
     spec.instance_veh = VehicleCamera:new(self, RosVehicle)
     spec.xml_path = spec.instance_veh.vehicle.configFileName
     spec.xmlFile = loadXMLFile("vehicle", spec.xml_path)
-
-
 end
 
 

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -31,10 +31,9 @@ end
 
 function RosVehicle.registerFunctions(vehicleType)
     SpecializationUtil.registerFunction(vehicleType, "addTF", RosVehicle.addTF)
-    SpecializationUtil.registerFunction(vehicleType, "fillLaserData", RosVehicle.fillLaserData)
     SpecializationUtil.registerFunction(vehicleType, "getLaserFrameNode", RosVehicle.getLaserFrameNode)
+    SpecializationUtil.registerFunction(vehicleType, "pubLaserScan", RosVehicle.pubLaserScan)
     SpecializationUtil.registerFunction(vehicleType, "pubOdom", RosVehicle.pubOdom)
-
 end
 
 
@@ -138,7 +137,8 @@ function RosVehicle:addTF(tf_msg, TransformStamped)
 end
 
 
-function RosVehicle:fillLaserData(ros_time, tf_msg, pub_scan)
+function RosVehicle:pubLaserScan(ros_time, tf_msg, pub_scan)
+
     local spec = self.spec_rosVehicle
     -- make sure the vechile is drivable and has laser frame node
     if self:getLaserFrameNode() then

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -68,6 +68,11 @@ function RosVehicle:onLoad()
     spec.instance_veh = VehicleCamera:new(self, RosVehicle)
     spec.xml_path = spec.instance_veh.vehicle.configFileName
     spec.xmlFile = loadXMLFile("vehicle", spec.xml_path)
+
+    -- initialize publishers for Odometry, LaserScan and Imu messages for each rosVehicle
+    spec.pub_odom = Publisher.new(ModROS._conx, spec.ros_veh_name_with_id .."/odom", nav_msgs_Odometry)
+    spec.pub_scan = Publisher.new(ModROS._conx, spec.ros_veh_name_with_id .."/scan", sensor_msgs_LaserScan)
+    spec.pub_imu = Publisher.new(ModROS._conx, spec.ros_veh_name_with_id .."/imu", sensor_msgs_Imu)
 end
 
 

--- a/src/vehicles/RosVehicle.lua
+++ b/src/vehicles/RosVehicle.lua
@@ -21,6 +21,7 @@ RosVehicle = {}
 
 
 function RosVehicle.prerequisitesPresent(specializations)
+    -- make <drivable> spec as a prerequisite for now so that we only control vehicles which are drivable
     return SpecializationUtil.hasSpecialization(Drivable, specializations)
 end
 
@@ -50,6 +51,7 @@ end
 -- end
 
 
+-- this will be loaded for every rosVehicle vehicle before starting the game
 function RosVehicle:onLoad()
     -- rosVehicle namespace
     self.spec_rosVehicle = self["spec_" .. g_modROSModName .. ".rosVehicle"]
@@ -80,7 +82,6 @@ function RosVehicle:pubOdom(ros_time, tf_msg)
 
     local spec = self.spec_rosVehicle
     local vehicle_base_link = spec.base_link_frame
-
 
     -- retrieve the vehicle node we're interested in:
     -- A drivable vehicle is often composed of 2 components and the first component is the main part.


### PR DESCRIPTION
This PR is to fix #15 and fix #16

Major changes:
- allow each vehicle publish messages  (`Odometry`, `LaserScan`, `Imu`) to its own topics (e.g. `veh_ns + "/odom"`)
- `control_only_active_one` is decoupled from `LaserScan` messages
- add default laser scanner's settings to support vehicles that are not pre-configured in the `mod_config.lua` 
