### PR TITLE
Fix the invalid topic basename errors for certain vehicle classes

### DIFF
--- a/src/utils/ros.lua
+++ b/src/utils/ros.lua
@@ -26,8 +26,11 @@ ros.Time = {}
 
 -- function for legalizing a name for ROS resources
 function ros.Names.sanatize(veh_name)
-    -- replace whitespace with underscores and uppercase with lowercase to meet the ROS naming conventions for TF
-    return veh_name:gsub(" ", "_"):lower()
+    -- in order to meet the ROS naming conventions, we need to sanitize illegal names from FS by using
+    -- 1. "%W" to replace every non-alphanumeric character with an underscore "_"
+    -- 2. "+" modifier to get the longest sequence of non-alphanumeric character, i.e. "___" -> "_" (replace consecutive _ with single _)
+    -- 3. :lower() to replace every uppercase letter with lowercase one
+    return veh_name:gsub("%W+", "_"):lower()
 end
 
 

--- a/src/utils/ros.lua
+++ b/src/utils/ros.lua
@@ -30,7 +30,19 @@ function ros.Names.sanatize(veh_name)
     -- 1. "%W" to replace every non-alphanumeric character with an underscore "_"
     -- 2. "+" modifier to get the longest sequence of non-alphanumeric character, i.e. "___" -> "_" (replace consecutive _ with single _)
     -- 3. :lower() to replace every uppercase letter with lowercase one
-    return veh_name:gsub("%W+", "_"):lower()
+    veh_name = veh_name:gsub("%W+", "_"):lower()
+
+    -- make sure names do not start or end with underscores
+    -- if it starts with an underscore, remove the first character
+    if veh_name:sub(1,1) == "_" then
+        veh_name = veh_name:sub(2,-1)
+    end
+
+    -- if it ends with an underscore, remove the last character
+    if veh_name:sub(-1,-1) == "_" then
+        veh_name = veh_name:sub(1,-2)
+    end
+    return veh_name
 end
 
 

--- a/src/utils/ros.lua
+++ b/src/utils/ros.lua
@@ -30,19 +30,15 @@ function ros.Names.sanatize(veh_name)
     -- 1. "%W" to replace every non-alphanumeric character with an underscore "_"
     -- 2. "+" modifier to get the longest sequence of non-alphanumeric character, i.e. "___" -> "_" (replace consecutive _ with single _)
     -- 3. :lower() to replace every uppercase letter with lowercase one
-    veh_name = veh_name:gsub("%W+", "_"):lower()
+    local local_veh_name = veh_name:gsub("%W+", "_"):lower()
 
     -- make sure names do not start or end with underscores
     -- if it starts with an underscore, remove the first character
-    if veh_name:sub(1,1) == "_" then
-        veh_name = veh_name:sub(2,-1)
-    end
-
     -- if it ends with an underscore, remove the last character
-    if veh_name:sub(-1,-1) == "_" then
-        veh_name = veh_name:sub(1,-2)
-    end
-    return veh_name
+    local_veh_name = local_veh_name:gsub("^_", "")
+    local_veh_name = local_veh_name:gsub("_$", "")
+
+    return local_veh_name
 end
 
 


### PR DESCRIPTION
This PR is to fix #46.

Now every illegal character, namely non-alphanumeric character is replaced with an underscore (`_`).