### PR TITLE
Remove need for `ROS_messages` redirected named-pipe

### DIFF
--- a/src/modROS.lua
+++ b/src/modROS.lua
@@ -77,7 +77,7 @@ function ModROS:loadMap()
     self.l_v_z_0 = 0
 
     -- initialise connection to the Python side (but do not connect it yet)
-    self.path = ModROS.MOD_DIR .. "ROS_messages"
+    self.path = "\\\\.\\pipe\\FS19_modROS_pipe"
     self._conx = WriteOnlyFileConnection.new(self.path)
 
     -- initialise no-namespace-specific publishers


### PR DESCRIPTION
Turns out it's actually possible to directly open a named pipe, so we can do away with the redirect-named-pipe-to-file-in-mod-dir work-around.

Not sure why it works now, as from earlier tests we had the impression it didn't, but seeing as this simplifies things quite a bit, I'm not complaining.

See https://github.com/tud-cor/fs_mod_ros_windows/pull/10 for the changes on the `fs_mod_ros_windows` side.
