### PR TITLE
laser_scanner: fix off-by-one in `angle_increment` calculation

### DIFF
--- a/src/utils/LaserScanner.lua
+++ b/src/utils/LaserScanner.lua
@@ -132,7 +132,7 @@ function LaserScanner:doScan(ros_time, tf_msg)
         -- with zero angle being forward along the x axis, scanning fov +-180 degrees
         scan_msg.angle_min = spec.laser_scan_obj.vehicle_table.laser_scan.angle_min
         scan_msg.angle_max = spec.laser_scan_obj.vehicle_table.laser_scan.angle_max
-        scan_msg.angle_increment = spec.laser_scan_obj.LS_FOV / spec.laser_scan_obj.vehicle_table.laser_scan.num_rays
+        scan_msg.angle_increment = spec.laser_scan_obj.LS_FOV / (spec.laser_scan_obj.vehicle_table.laser_scan.num_rays - 1)
         -- assume sensor gives 50 scans per second
         scan_msg.time_increment = (1.0 / 50) / spec.laser_scan_obj.vehicle_table.laser_scan.num_rays
         --scan_msg.scan_time = 0.0  -- we don't set this field (TODO: should we?)


### PR DESCRIPTION
This may fix the issues experienced by @ashchennikov in #57.

Some quick tests (`fov: 5 degrees` and `fov: 90 degrees`) show this to work:

![image](https://github.com/tud-cor/FS19_modROS/assets/4550046/3b06a087-449b-4952-a9f8-33b72c548b9e)

(scans of the little pickets in front of the isles of the gas station with FOV: 90 degrees (`[-45; 45]`). Note: perspective is not identical, the laser scanner is mounted in front of the vehicle)

If you're still interested @ashchennikov, please give this a test.

I'll merge this next week, unless I find something is still wrong and/or someone reports an(other) issue with it.
